### PR TITLE
feat(qudp): imple sendmmsg

### DIFF
--- a/qudp/examples/receiver.rs
+++ b/qudp/examples/receiver.rs
@@ -17,7 +17,7 @@ const BUFFER_SIZE: usize = 1200;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    #[arg(short,long, default_value_t = String::from("127.0.0.1:12345"))]
+    #[arg(short,long, default_value_t = String::from("[::]:12345"))]
     bind: String,
 }
 
@@ -77,7 +77,7 @@ impl Future for Receiver {
         let mut n = 0;
 
         for (_, hdr) in hdrs.iter().enumerate().take(ret) {
-            n += hdr.seg_size.unwrap() as usize;
+            n += hdr.seg_size as usize;
             println!("received from {:?} ttl {}", hdr.src, hdr.ttl);
         }
 

--- a/qudp/examples/sender.rs
+++ b/qudp/examples/sender.rs
@@ -1,16 +1,13 @@
+use bytes::Bytes;
+use clap::{command, Parser};
+use qudp::{ArcUsc, PacketHeader};
+use std::task;
 use std::{
     future::Future,
     io::{self, IoSlice},
     iter,
     task::{ready, Poll},
 };
-
-use bytes::Bytes;
-use clap::{command, Parser};
-
-use qudp::{ArcUsc, PacketHeader};
-
-use std::task;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -24,7 +21,7 @@ struct Args {
     #[arg(long, default_value_t = 1200)]
     msg_size: usize,
 
-    #[arg(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 1_000)]
     msg_count: usize,
 
     #[arg(long, default_value_t = false)]

--- a/qudp/examples/sender.rs
+++ b/qudp/examples/sender.rs
@@ -18,7 +18,7 @@ struct Args {
     #[arg(long, default_value_t = String::from("[::]:0"))]
     src: String,
 
-    #[arg(long, default_value_t = String::from("127.0.0.1:12345"))]
+    #[arg(long, default_value_t = String::from("[::1]:12345"))]
     dst: String,
 
     #[arg(long, default_value_t = 1200)]
@@ -27,8 +27,8 @@ struct Args {
     #[arg(long, default_value_t = 10)]
     msg_count: usize,
 
-    #[arg(long)]
-    seg_size: Option<u16>,
+    #[arg(long, default_value_t = false)]
+    gso: bool,
 }
 
 #[tokio::main]
@@ -45,7 +45,8 @@ async fn main() {
         dst,
         ttl: 64,
         ecn: Some(1),
-        seg_size: args.seg_size,
+        seg_size: args.msg_size as u16,
+        gso: args.gso,
     };
 
     let sender = Sender {

--- a/qudp/src/lib.rs
+++ b/qudp/src/lib.rs
@@ -1,4 +1,4 @@
-use msg::Cmsg;
+use msg::Encoder;
 use socket2::{Domain, Socket, Type};
 use std::io::IoSlice;
 use std::io::IoSliceMut;
@@ -18,7 +18,8 @@ pub struct PacketHeader {
     pub dst: SocketAddr,
     pub ttl: u8,
     pub ecn: Option<u8>,
-    pub seg_size: Option<u16>,
+    pub seg_size: u16,
+    pub gso: bool,
 }
 
 impl Default for PacketHeader {
@@ -28,7 +29,8 @@ impl Default for PacketHeader {
             dst: SocketAddr::from(([0, 0, 0, 0], 0)),
             ttl: DEFAULT_TTL as u8,
             ecn: None,
-            seg_size: None,
+            gso: false,
+            seg_size: 0,
         }
     }
 }
@@ -105,7 +107,7 @@ trait Io {
 trait Gso: Io {
     fn max_gso_segments(&self) -> usize;
 
-    fn set_segment_size(encoder: &mut Cmsg, segment_size: u16);
+    fn set_segment_size(encoder: &mut Encoder, segment_size: u16);
 }
 
 trait Gro: Io {


### PR DESCRIPTION
sendmmsg with gso

```bash
strace -c -e trace=%net ../target/debug/examples/sender --gso                                                    ~/quix/qudp
sent 1200000000 bytes
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00    0.191681         660       290           sendmmsg
  0.00    0.000002           0         3           getsockname
  0.00    0.000001           0         2           getsockopt
  0.00    0.000000           0         3           socket
  0.00    0.000000           0         3           bind
  0.00    0.000000           0         1           socketpair
  0.00    0.000000           0        11         2 setsockopt
------ ----------- ----------- --------- --------- ----------------
100.00    0.191684         612       313         2 total
```

sendmmsg without gso

```bash
strace -c -e trace=%net ../target/debug/examples/sender                                                          ~/quix/qudp
sent 1200000000 bytes
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00    5.670731         362     15625           sendmmsg
  0.00    0.000118          10        11         2 setsockopt
  0.00    0.000046          15         3           socket
  0.00    0.000028           9         3           bind
  0.00    0.000016           5         3           getsockname
  0.00    0.000014          14         1           socketpair
  0.00    0.000008           4         2           getsockopt
------ ----------- ----------- --------- --------- ----------------
100.00    5.670961         362     15648         2 total
```

sendmsg with gso

```bash
strace -c -e trace=%net ../target/debug/examples/sender --gso                                                    ~/quix/qudp
sent 1200000000 bytes
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 99.96    0.431158          23     18519           sendmsg
  0.02    0.000070           6        11         2 setsockopt
  0.01    0.000038          12         3           socket
  0.00    0.000017           5         3           bind
  0.00    0.000013           4         3           getsockname
  0.00    0.000013          13         1           socketpair
  0.00    0.000010           5         2           getsockopt
------ ----------- ----------- --------- --------- ----------------
100.00    0.431319          23     18542         2 total
```

sendmsg without gso

```bash
strace -c -e trace=%net ../target/debug/examples/sender                                                          ~/quix/qudp
sent 1200000000 bytes
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00   12.810980          12   1000000           sendmsg
  0.00    0.000014          14         1           socketpair
  0.00    0.000002           0         3           getsockname
  0.00    0.000001           0         2           getsockopt
  0.00    0.000000           0         3           socket
  0.00    0.000000           0         3           bind
  0.00    0.000000           0        11         2 setsockopt
------ ----------- ----------- --------- --------- ----------------
100.00   12.810997          12   1000023         2 total
```