### PR TITLE
refactor: let ArcReliableFrameDeque be a single independent module

### DIFF
--- a/qrecovery/src/reliable.rs
+++ b/qrecovery/src/reliable.rs
@@ -24,22 +24,22 @@ pub enum ReliableFrame {
 /// 对于Initial和Handshake空间，仅需负责CryptoFrame的可靠传输
 /// 对与Data空间，则需负责上述ReliableFrame的可靠传输
 #[derive(Debug, Default, Deref, DerefMut)]
-pub struct RawReliableFrameDeque<T> {
+pub struct RawReliableFrameDeque {
     #[deref]
-    queue: VecDeque<T>,
+    queue: VecDeque<ReliableFrame>,
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct ArcReliableFrameDeque<T>(Arc<Mutex<RawReliableFrameDeque<T>>>);
+pub struct ArcReliableFrameDeque(Arc<Mutex<RawReliableFrameDeque>>);
 
-impl<T> ArcReliableFrameDeque<T> {
+impl ArcReliableFrameDeque {
     pub fn with_capacity(capacity: usize) -> Self {
         Self(Arc::new(Mutex::new(RawReliableFrameDeque {
             queue: VecDeque::with_capacity(capacity),
         })))
     }
 
-    pub fn lock_guard(&self) -> MutexGuard<'_, RawReliableFrameDeque<T>> {
+    pub fn lock_guard(&self) -> MutexGuard<'_, RawReliableFrameDeque> {
         self.0.lock().unwrap()
     }
 }

--- a/qrecovery/src/space.rs
+++ b/qrecovery/src/space.rs
@@ -1,11 +1,8 @@
 use std::ops::{Index, IndexMut};
 
-use deref_derive::Deref;
 use qbase::frame::CryptoFrame;
 
-use crate::reliable::{
-    rcvdpkt::ArcRcvdPktRecords, sentpkt::ArcSentPktRecords, ArcReliableFrameDeque, ReliableFrame,
-};
+use crate::reliable::{rcvdpkt::ArcRcvdPktRecords, sentpkt::ArcSentPktRecords, ReliableFrame};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Epoch {
@@ -45,10 +42,8 @@ where
     }
 }
 
-#[derive(Debug, Default, Deref, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct RawSpace<T> {
-    #[deref]
-    reliable_frame_queue: ArcReliableFrameDeque<T>,
     sent_pkt_records: ArcSentPktRecords<T>,
     rcvd_pkt_records: ArcRcvdPktRecords,
 }
@@ -56,7 +51,6 @@ pub struct RawSpace<T> {
 impl<T> RawSpace<T> {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            reliable_frame_queue: ArcReliableFrameDeque::with_capacity(capacity),
             sent_pkt_records: ArcSentPktRecords::with_capacity(capacity),
             rcvd_pkt_records: ArcRcvdPktRecords::with_capacity(capacity),
         }
@@ -96,15 +90,12 @@ pub enum Space {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Deref;
-
     use qbase::packet::PacketNumber;
 
     #[test]
     fn test_initial_space() {
         use super::*;
         let space = InitialSpace::with_capacity(10);
-        assert_eq!(space.deref().lock_guard().len(), 0);
         // assert_eq!(AsRef::<ArcSentPktRecords<_>>::as_ref(&space).lock_guard().len(), 0);
         assert_eq!(
             AsRef::<ArcRcvdPktRecords>::as_ref(&space).decode_pn(PacketNumber::encode(0, 0)),

--- a/qrecovery/src/streams.rs
+++ b/qrecovery/src/streams.rs
@@ -9,11 +9,7 @@ use deref_derive::Deref;
 use futures::Future;
 use qbase::{error::Error, streamid::Role};
 
-use crate::{
-    recv::Reader,
-    reliable::{ArcReliableFrameDeque, ReliableFrame},
-    send::Writer,
-};
+use crate::{recv::Reader, reliable::ArcReliableFrameDeque, send::Writer};
 
 pub mod data;
 pub mod listener;
@@ -26,7 +22,7 @@ impl DataStreams {
         role: Role,
         max_bi_streams: u64,
         max_uni_streams: u64,
-        reliable_frame_queue: ArcReliableFrameDeque<ReliableFrame>,
+        reliable_frame_queue: ArcReliableFrameDeque,
     ) -> Self {
         Self(Arc::new(data::RawDataStreams::with_role_and_limit(
             role,


### PR DESCRIPTION
将可靠帧队列放在Space里面，然而InitialSpace和HandshakeSpace只需负责CryptoFrame的可靠性，用不了可靠帧队列。

因此，全局只有数据空间的可靠帧队列一个实例了。

看了下ArcSentPktRecords::may_loss_pkt函数的返回值是一个需要重传的帧的迭代器，完全可以将可靠帧队列单独拿出来了。

由上，有了这个提交，将可靠帧队列，完全放在Connection中单独维护