### PR TITLE
fix(quic): update path receive time for existing connections

### DIFF
--- a/quic/src/lib.rs
+++ b/quic/src/lib.rs
@@ -110,7 +110,7 @@ pub fn get_usc(bind_addr: &SocketAddr) -> ArcUsc {
                                     .get(&ConnKey::Client(dcid))
                                     .or_else(|| CONNECTIONS.get(&ConnKey::Server(dcid)))
                                 {
-                                    Some(_conn) => {} //TODO: conn.update_path_recv_time(pathway),
+                                    Some(conn) => conn.update_path_recv_time(pathway),
                                     None => log::error!("No connection found for Data packet"),
                                 }
                             }


### PR DESCRIPTION
Update the path receive time for existing connections when receiving a
data packet.

This used to cause a deadlock, but it won't now.