### PR TITLE
fix: fix single_match and too_long_first_doc_paragraph

### DIFF
--- a/qbase/src/packet.rs
+++ b/qbase/src/packet.rs
@@ -69,9 +69,9 @@ pub enum Packet {
     Data(DataPacket),
 }
 
-/// The parsing here does not involve removing header protection or decrypting the packet. It only parses information such as packet type and connection ID,
-/// and prepares for further delivery to the connection by finding the connection ID. The removal of header protection and decryption of the packet is done at the connection layer.
-/// The received packet is a BytesMut, in order to make as few copies as possible until it is read by the application layer.
+// The parsing here does not involve removing header protection or decrypting the packet. It only parses information such as packet type and connection ID,
+// and prepares for further delivery to the connection by finding the connection ID. The removal of header protection and decryption of the packet is done at the connection layer.
+// The received packet is a BytesMut, in order to make as few copies as possible until it is read by the application layer.
 #[derive(Debug)]
 pub struct PacketReader {
     raw: BytesMut,

--- a/qbase/src/packet/header.rs
+++ b/qbase/src/packet/header.rs
@@ -25,6 +25,7 @@ pub trait GetType {
 
 /// When encoding a packet for sending, we need to know the length of the packet,
 /// so this trait needs to be implemented.
+///
 /// However, the length field of the packet header is variable-length encoded and
 /// requires special handling, which is not considered within the scope of Encode::size.
 #[enum_dispatch]

--- a/qbase/src/packet/type.rs
+++ b/qbase/src/packet/type.rs
@@ -76,6 +76,8 @@ impl<const R: u8> GetPacketNumberLength for ClearBits<R> {
     }
 }
 
+/// The Type of the packet
+///
 /// The Type is only extracted from the first 3 or 4 bits of the first byte, these contents
 /// are not protected, there is no distinction between ciphertext and plaintext.
 /// For simplicity and future-oriented considerations, the Version of the long packet header

--- a/qbase/src/util/async_deque.rs
+++ b/qbase/src/util/async_deque.rs
@@ -137,15 +137,12 @@ impl<T> ArcAsyncDequeWriter<'_, T> {
 
 impl<T> Drop for ArcAsyncDequeWriter<'_, T> {
     fn drop(&mut self) {
-        match &mut self.guard.queue {
-            Some(queue) => {
-                if queue.len() > self.old_len {
-                    if let Some(waker) = self.guard.waker.take() {
-                        waker.wake();
-                    }
+        if let Some(queue) = &mut self.guard.queue {
+            if queue.len() > self.old_len {
+                if let Some(waker) = self.guard.waker.take() {
+                    waker.wake();
                 }
             }
-            None => {}
         }
     }
 }

--- a/qbase/src/varint.rs
+++ b/qbase/src/varint.rs
@@ -170,6 +170,7 @@ pub fn be_varint(input: &[u8]) -> IResult<&[u8], VarInt> {
 }
 
 /// Write a variable-length integer.
+///
 /// `put_varint` will write the smallest number of bytes needed to represent the value.
 /// `encode_varint` will write the specified number of bytes, and panic if the specified number of bytes
 /// is less than the smallest number of bytes needed to repressent the value.

--- a/qrecovery/src/recv/incoming.rs
+++ b/qrecovery/src/recv/incoming.rs
@@ -26,8 +26,8 @@ impl Incoming {
         let mut recver = self.0.lock().unwrap();
         let inner = recver.deref_mut();
         let mut new_data_size = 0;
-        match inner {
-            Ok(receiving_state) => match receiving_state {
+        if let Ok(receiving_state) = inner {
+            match receiving_state {
                 Recver::Recv(r) => {
                     new_data_size = r.recv(stream_frame, body)?;
                 }
@@ -40,8 +40,7 @@ impl Incoming {
                 _ => {
                     log::debug!("ignored stream frame {:?}", stream_frame);
                 }
-            },
-            Err(_) => (),
+            }
         }
         Ok(new_data_size)
     }
@@ -49,16 +48,15 @@ impl Incoming {
     pub fn end(&self, final_size: u64) {
         let mut recver = self.0.lock().unwrap();
         let inner = recver.deref_mut();
-        match inner {
-            Ok(receiving_state) => match receiving_state {
+        if let Ok(receiving_state) = inner {
+            match receiving_state {
                 Recver::Recv(r) => {
                     *receiving_state = Recver::SizeKnown(r.determin_size(final_size));
                 }
                 _ => {
                     log::debug!("there is sth wrong, ignored finish");
                 }
-            },
-            Err(_) => (),
+            }
         }
     }
 
@@ -66,8 +64,8 @@ impl Incoming {
         // TODO: ResetStream中还有错误信息，比如http3的错误码，看是否能用到
         let mut recver = self.0.lock().unwrap();
         let inner = recver.deref_mut();
-        match inner {
-            Ok(receiving_state) => match receiving_state {
+        if let Ok(receiving_state) = inner {
+            match receiving_state {
                 Recver::Recv(r) => {
                     let final_size = r.recv_reset(reset_frame)?;
                     *receiving_state = Recver::ResetRcvd(final_size);
@@ -80,8 +78,7 @@ impl Incoming {
                     log::error!("there is sth wrong, ignored recv_reset");
                     unreachable!();
                 }
-            },
-            Err(_) => (),
+            }
         }
         Ok(())
     }

--- a/qrecovery/src/recv/rcvbuf.rs
+++ b/qrecovery/src/recv/rcvbuf.rs
@@ -41,6 +41,8 @@ impl Segment {
     }
 }
 
+/// Received data of a stream is stored in RecvBuf.
+///
 /// The receiving buffer is relatively simple, as it receives segmented data
 /// that may not be continuous. It sequentially stores the received data
 /// fragments and then reassembles them into a continuous data stream for

--- a/qrecovery/src/recv/reader.rs
+++ b/qrecovery/src/recv/reader.rs
@@ -24,8 +24,8 @@ impl Reader {
         debug_assert!(error_code <= VARINT_MAX);
         let mut recver = self.0.lock().unwrap();
         let inner = recver.deref_mut();
-        match inner {
-            Ok(receiving_state) => match receiving_state {
+        if let Ok(receiving_state) = inner {
+            match receiving_state {
                 Recver::Recv(r) => {
                     r.stop(error_code);
                 }
@@ -33,8 +33,7 @@ impl Reader {
                     r.stop(error_code);
                 }
                 _ => (),
-            },
-            Err(_) => (),
+            }
         }
     }
 }
@@ -81,27 +80,24 @@ impl Drop for Reader {
     fn drop(&mut self) {
         let mut recver = self.0.lock().unwrap();
         let inner = recver.deref_mut();
-        match inner {
-            // strict mode: don't forget to call stop with the error code when an
-            // abnormal termination occurs, or it will panic.
-            Ok(receiving_state) => match receiving_state {
+        if let Ok(receiving_state) = inner {
+            match receiving_state {
                 Recver::Recv(r) => {
                     assert!(
                         r.is_stopped(),
                         r#"RecvStream in Recv State must be 
-                            stopped with error code before dropped!"#
+                        stopped with error code before dropped!"#
                     )
                 }
                 Recver::SizeKnown(r) => {
                     assert!(
                         r.is_stopped(),
                         r#"RecvStream in Recv State must be 
-                            stopped with error code before dropped!"#
+                        stopped with error code before dropped!"#
                     )
                 }
                 _ => (),
-            },
-            Err(_) => (),
+            }
         }
     }
 }

--- a/qrecovery/src/send/writer.rs
+++ b/qrecovery/src/send/writer.rs
@@ -123,8 +123,8 @@ impl Writer {
     pub fn cancel(self, err_code: u64) {
         let mut sender = self.0.lock().unwrap();
         let inner = sender.deref_mut();
-        match inner {
-            Ok(sending_state) => match sending_state {
+        if let Ok(sending_state) = inner {
+            match sending_state {
                 Sender::Ready(s) => {
                     s.cancel(err_code);
                 }
@@ -135,8 +135,7 @@ impl Writer {
                     s.cancel(err_code);
                 }
                 _ => (),
-            },
-            Err(_) => (),
+            }
         };
     }
 }
@@ -145,34 +144,31 @@ impl Drop for Writer {
     fn drop(&mut self) {
         let mut sender = self.0.lock().unwrap();
         let inner = sender.deref_mut();
-        match inner {
-            // strict mode: don't forget to call cancel with the error code when an
-            // abnormal termination occurs, or it will panic.
-            Ok(sending_state) => match sending_state {
+        if let Ok(sending_state) = inner {
+            match sending_state {
                 Sender::Ready(s) => {
                     assert!(
                         s.is_cancelled(),
                         "SendingStream in Ready State must be 
-                            cancelled with error code before dropped!"
+                        cancelled with error code before dropped!"
                     );
                 }
                 Sender::Sending(s) => {
                     assert!(
                         s.is_cancelled(),
                         "SendingStream in Sending State must be 
-                            cancelled with error code before dropped!"
+                        cancelled with error code before dropped!"
                     );
                 }
                 Sender::DataSent(s) => {
                     assert!(
                         s.is_cancelled(),
                         "SendingStream in DataSent State must be 
-                            cancelled with error code before dropped!"
+                        cancelled with error code before dropped!"
                     );
                 }
                 _ => (),
-            },
-            Err(_) => (),
+            }
         };
     }
 }


### PR DESCRIPTION
Nightly新加的lint，稳定版的clippy检测不到

我们的格式化检查使用了nightly的，那clippy是否也使用nightly的呢，这样会有更完多的lint