### PR TITLE
refactor(qbase): remove belongs_to method from BeFrame

### DIFF
--- a/qbase/src/frame/crypto.rs
+++ b/qbase/src/frame/crypto.rs
@@ -10,7 +10,6 @@ use std::ops::Range;
 use nom::sequence::tuple;
 
 use crate::{
-    packet::r#type::Type,
     util::{DescribeData, WriteData},
     varint::{be_varint, VarInt, WriteVarInt, VARINT_MAX},
 };
@@ -26,20 +25,6 @@ const CRYPTO_FRAME_TYPE: u8 = 0x06;
 impl super::BeFrame for CryptoFrame {
     fn frame_type(&self) -> super::FrameType {
         super::FrameType::Crypto
-    }
-
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // IH_1
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::INITIAL))
-                | Type::Long(V1(Ver1::HANDSHAKE))
-                | Type::Short(OneRtt(_))
-        )
     }
 
     fn max_encoding_size(&self) -> usize {
@@ -91,7 +76,6 @@ impl CryptoFrame {
     }
 }
 
-// nom parser for CRYPTO_FRAME
 pub fn be_crypto_frame(input: &[u8]) -> nom::IResult<&[u8], CryptoFrame> {
     let (remain, (offset, length)) = tuple((be_varint, be_varint))(input)?;
     if offset.into_inner() + offset.into_inner() > VARINT_MAX {

--- a/qbase/src/frame/data_blocked.rs
+++ b/qbase/src/frame/data_blocked.rs
@@ -3,10 +3,7 @@
 //   Maximum Data (i),
 // }
 
-use crate::{
-    packet::r#type::Type,
-    varint::{be_varint, VarInt, WriteVarInt},
-};
+use crate::varint::{be_varint, VarInt, WriteVarInt};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct DataBlockedFrame {
@@ -20,18 +17,6 @@ impl super::BeFrame for DataBlockedFrame {
         super::FrameType::Crypto
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
-    }
-
     fn max_encoding_size(&self) -> usize {
         1 + 8
     }
@@ -41,7 +26,6 @@ impl super::BeFrame for DataBlockedFrame {
     }
 }
 
-// nom parser for DATA_BLOCKED_FRAME
 pub fn be_data_blocked_frame(input: &[u8]) -> nom::IResult<&[u8], DataBlockedFrame> {
     use nom::combinator::map;
     map(be_varint, |limit| DataBlockedFrame { limit })(input)

--- a/qbase/src/frame/datagram.rs
+++ b/qbase/src/frame/datagram.rs
@@ -2,13 +2,12 @@
 //   Type (i) = 0x30..0x31,
 //   [Length (i)],
 //   Datagram Data (..),
-// {
+// }
 
 use nom::IResult;
 
 use super::{BeFrame, FrameType};
 use crate::{
-    packet::r#type::Type,
     util::{DescribeData, WriteData},
     varint::{be_varint, VarInt, WriteVarInt},
 };
@@ -27,18 +26,6 @@ impl DatagramFrame {
 impl BeFrame for DatagramFrame {
     fn frame_type(&self) -> FrameType {
         FrameType::Datagram(self.length.is_some() as _)
-    }
-
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
     }
 
     fn max_encoding_size(&self) -> usize {

--- a/qbase/src/frame/handshake_done.rs
+++ b/qbase/src/frame/handshake_done.rs
@@ -2,8 +2,6 @@
 //   Type (i) = 0x1e,
 // }
 
-use crate::packet::r#type::Type;
-
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct HandshakeDoneFrame;
 
@@ -13,15 +11,8 @@ impl super::BeFrame for HandshakeDoneFrame {
     fn frame_type(&self) -> super::FrameType {
         super::FrameType::HandshakeDone
     }
-
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::short::OneRtt;
-        // ___1
-        matches!(packet_type, Type::Short(OneRtt(_)))
-    }
 }
 
-// nom parser for HANDSHAKE_DONE_FRAME
 #[allow(unused)]
 pub fn be_handshake_done_frame(input: &[u8]) -> nom::IResult<&[u8], HandshakeDoneFrame> {
     Ok((input, HandshakeDoneFrame))

--- a/qbase/src/frame/io.rs
+++ b/qbase/src/frame/io.rs
@@ -125,9 +125,11 @@ pub fn be_frame(raw: &Bytes, packet_type: Type) -> Result<(usize, Frame, bool), 
 }
 
 pub trait WriteFrame<F> {
+    /// BufMut write extension for frame.
     fn put_frame(&mut self, frame: &F);
 }
 
 pub trait WriteDataFrame<F, D: DescribeData> {
+    /// BufMut write extension for frame with data.
     fn put_data_frame(&mut self, frame: &F, data: &D);
 }

--- a/qbase/src/frame/max_data.rs
+++ b/qbase/src/frame/max_data.rs
@@ -3,10 +3,7 @@
 //   Maximum Data (i),
 // }
 
-use crate::{
-    packet::r#type::Type,
-    varint::{be_varint, VarInt, WriteVarInt},
-};
+use crate::varint::{be_varint, VarInt, WriteVarInt};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct MaxDataFrame {
@@ -20,18 +17,6 @@ impl super::BeFrame for MaxDataFrame {
         super::FrameType::MaxData
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
-    }
-
     fn max_encoding_size(&self) -> usize {
         1 + 8
     }
@@ -41,7 +26,6 @@ impl super::BeFrame for MaxDataFrame {
     }
 }
 
-// nom parser for MAX_DATA_FRAME
 pub fn be_max_data_frame(input: &[u8]) -> nom::IResult<&[u8], MaxDataFrame> {
     use nom::combinator::map;
     map(be_varint, |max_data| MaxDataFrame { max_data })(input)

--- a/qbase/src/frame/max_stream_data.rs
+++ b/qbase/src/frame/max_stream_data.rs
@@ -5,7 +5,6 @@
 // }
 
 use crate::{
-    packet::r#type::Type,
     streamid::{be_streamid, StreamId, WriteStreamId},
     varint::{be_varint, VarInt, WriteVarInt},
 };
@@ -23,18 +22,6 @@ impl super::BeFrame for MaxStreamDataFrame {
         super::FrameType::MaxStreamData
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
-    }
-
     fn max_encoding_size(&self) -> usize {
         1 + 8 + 8
     }
@@ -44,7 +31,6 @@ impl super::BeFrame for MaxStreamDataFrame {
     }
 }
 
-// nom parser for MAX_STREAM_DATA_FRAME
 pub fn be_max_stream_data_frame(input: &[u8]) -> nom::IResult<&[u8], MaxStreamDataFrame> {
     use nom::{combinator::map, sequence::pair};
     map(

--- a/qbase/src/frame/max_streams.rs
+++ b/qbase/src/frame/max_streams.rs
@@ -4,7 +4,6 @@
 // }
 
 use crate::{
-    packet::r#type::Type,
     streamid::MAX_STREAM_ID,
     varint::{be_varint, VarInt, WriteVarInt},
 };
@@ -27,18 +26,6 @@ impl super::BeFrame for MaxStreamsFrame {
         })
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
-    }
-
     fn max_encoding_size(&self) -> usize {
         1 + 8
     }
@@ -51,7 +38,6 @@ impl super::BeFrame for MaxStreamsFrame {
     }
 }
 
-// nom parser for MAX_STREAMS_FRAME
 pub fn max_streams_frame_with_dir(
     dir: u8,
 ) -> impl Fn(&[u8]) -> nom::IResult<&[u8], MaxStreamsFrame> {

--- a/qbase/src/frame/new_connection_id.rs
+++ b/qbase/src/frame/new_connection_id.rs
@@ -9,7 +9,6 @@
 
 use crate::{
     cid::{be_connection_id, ConnectionId, UniqueCid, WriteConnectionId},
-    packet::r#type::Type,
     token::{be_reset_token, ResetToken, RESET_TOKEN_SIZE},
     varint::{be_varint, VarInt, WriteVarInt},
 };
@@ -51,18 +50,6 @@ impl NewConnectionIdFrame {
 impl super::BeFrame for NewConnectionIdFrame {
     fn frame_type(&self) -> super::FrameType {
         super::FrameType::NewConnectionId
-    }
-
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
     }
 
     fn max_encoding_size(&self) -> usize {

--- a/qbase/src/frame/new_token.rs
+++ b/qbase/src/frame/new_token.rs
@@ -4,10 +4,7 @@
 //   Token (..),
 // }
 
-use crate::{
-    packet::r#type::Type,
-    varint::{be_varint, VarInt, WriteVarInt},
-};
+use crate::varint::{be_varint, VarInt, WriteVarInt};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewTokenFrame {
@@ -21,12 +18,6 @@ impl super::BeFrame for NewTokenFrame {
         super::FrameType::NewToken
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::short::OneRtt;
-        // ___1
-        matches!(packet_type, Type::Short(OneRtt(_)))
-    }
-
     fn max_encoding_size(&self) -> usize {
         // token's length could not exceed 20
         1 + 1 + self.token.len()
@@ -37,7 +28,6 @@ impl super::BeFrame for NewTokenFrame {
     }
 }
 
-// nom parser for NEW_TOKEN_FRAME
 pub fn be_new_token_frame(input: &[u8]) -> nom::IResult<&[u8], NewTokenFrame> {
     use nom::{
         bytes::streaming::take,

--- a/qbase/src/frame/padding.rs
+++ b/qbase/src/frame/padding.rs
@@ -2,8 +2,6 @@
 //   Type (i) = 0x00,
 // }
 
-use crate::packet::r#type::Type;
-
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PaddingFrame;
 
@@ -13,24 +11,8 @@ impl super::BeFrame for PaddingFrame {
     fn frame_type(&self) -> super::FrameType {
         super::FrameType::Padding
     }
-
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // IH01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::INITIAL))
-                | Type::Long(V1(Ver1::HANDSHAKE))
-                | Type::Long(V1(Ver1::ZERO_RTT))
-                | Type::Short(OneRtt(_))
-        )
-    }
 }
 
-// nom parser for PADDING_FRAME
 #[allow(dead_code)]
 pub fn be_padding_frame(input: &[u8]) -> nom::IResult<&[u8], PaddingFrame> {
     Ok((input, PaddingFrame))

--- a/qbase/src/frame/path_challenge.rs
+++ b/qbase/src/frame/path_challenge.rs
@@ -5,8 +5,6 @@
 
 use deref_derive::Deref;
 
-use crate::packet::r#type::Type;
-
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deref)]
 pub struct PathChallengeFrame {
     #[deref]
@@ -36,18 +34,6 @@ impl super::BeFrame for PathChallengeFrame {
         super::FrameType::PathChallenge
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
-    }
-
     fn max_encoding_size(&self) -> usize {
         1 + self.data.len()
     }
@@ -57,7 +43,6 @@ impl super::BeFrame for PathChallengeFrame {
     }
 }
 
-// nom parser for PATH_CHALLENGE_FRAME
 pub fn be_path_challenge_frame(input: &[u8]) -> nom::IResult<&[u8], PathChallengeFrame> {
     use nom::{bytes::streaming::take, combinator::map};
     map(take(8usize), PathChallengeFrame::from_slice)(input)

--- a/qbase/src/frame/path_response.rs
+++ b/qbase/src/frame/path_response.rs
@@ -7,8 +7,6 @@ use std::ops::Deref;
 
 use deref_derive::Deref;
 
-use crate::packet::r#type::Type;
-
 #[derive(Debug, Clone, Copy, Default, Deref, PartialEq, Eq)]
 pub struct PathResponseFrame {
     #[deref]
@@ -37,12 +35,6 @@ impl super::BeFrame for PathResponseFrame {
         super::FrameType::PathResponse
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::short::OneRtt;
-        // ___1
-        matches!(packet_type, Type::Short(OneRtt(_)))
-    }
-
     fn max_encoding_size(&self) -> usize {
         1 + self.data.len()
     }
@@ -52,13 +44,11 @@ impl super::BeFrame for PathResponseFrame {
     }
 }
 
-// nom parser for PATH_RESPONSE_FRAME
 pub fn be_path_response_frame(input: &[u8]) -> nom::IResult<&[u8], PathResponseFrame> {
     use nom::{bytes::complete::take, combinator::map};
     map(take(8usize), PathResponseFrame::from_slice)(input)
 }
 
-// BufMut write extension for PATH_RESPONSE_FRAME
 impl<T: bytes::BufMut> super::io::WriteFrame<PathResponseFrame> for T {
     fn put_frame(&mut self, frame: &PathResponseFrame) {
         self.put_u8(PATH_RESPONSE_FRAME_TYPE);

--- a/qbase/src/frame/ping.rs
+++ b/qbase/src/frame/ping.rs
@@ -2,8 +2,6 @@
 //   Type (i) = 0x01,
 // }
 
-use crate::packet::r#type::Type;
-
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PingFrame;
 
@@ -13,24 +11,8 @@ impl super::BeFrame for PingFrame {
     fn frame_type(&self) -> super::FrameType {
         super::FrameType::Ping
     }
-
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // IH01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::INITIAL))
-                | Type::Long(V1(Ver1::HANDSHAKE))
-                | Type::Long(V1(Ver1::ZERO_RTT))
-                | Type::Short(OneRtt(_))
-        )
-    }
 }
 
-// nom parser for PING_FRAME
 #[allow(unused)]
 pub fn be_ping_frame(input: &[u8]) -> nom::IResult<&[u8], PingFrame> {
     Ok((input, PingFrame))

--- a/qbase/src/frame/reset_stream.rs
+++ b/qbase/src/frame/reset_stream.rs
@@ -6,7 +6,6 @@
 // }
 
 use crate::{
-    packet::r#type::Type,
     streamid::{be_streamid, StreamId, WriteStreamId},
     varint::{be_varint, VarInt, WriteVarInt},
 };
@@ -25,18 +24,6 @@ impl super::BeFrame for ResetStreamFrame {
         super::FrameType::ResetStream
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
-    }
-
     fn max_encoding_size(&self) -> usize {
         1 + 8 + 8 + 8
     }
@@ -48,7 +35,6 @@ impl super::BeFrame for ResetStreamFrame {
     }
 }
 
-// nom parser for RESET_STREAM_FRAME
 pub fn be_reset_stream_frame(input: &[u8]) -> nom::IResult<&[u8], ResetStreamFrame> {
     use nom::{combinator::map, sequence::tuple};
     map(

--- a/qbase/src/frame/retire_connection_id.rs
+++ b/qbase/src/frame/retire_connection_id.rs
@@ -3,10 +3,7 @@
 //   Sequence Number (i),
 // }
 
-use crate::{
-    packet::r#type::Type,
-    varint::{be_varint, VarInt, WriteVarInt},
-};
+use crate::varint::{be_varint, VarInt, WriteVarInt};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RetireConnectionIdFrame {
@@ -20,18 +17,6 @@ impl super::BeFrame for RetireConnectionIdFrame {
         super::FrameType::RetireConnectionId
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
-    }
-
     fn max_encoding_size(&self) -> usize {
         1 + 8
     }
@@ -41,7 +26,6 @@ impl super::BeFrame for RetireConnectionIdFrame {
     }
 }
 
-// nom parser for RETIRE_CONNECTION_ID_FRAME
 pub fn be_retire_connection_id_frame(input: &[u8]) -> nom::IResult<&[u8], RetireConnectionIdFrame> {
     use nom::combinator::map;
     map(be_varint, |sequence| RetireConnectionIdFrame { sequence })(input)

--- a/qbase/src/frame/stop_sending.rs
+++ b/qbase/src/frame/stop_sending.rs
@@ -5,7 +5,6 @@
 // }
 
 use crate::{
-    packet::r#type::Type,
     streamid::{be_streamid, StreamId, WriteStreamId},
     varint::{be_varint, VarInt, WriteVarInt},
 };
@@ -23,18 +22,6 @@ impl super::BeFrame for StopSendingFrame {
         super::FrameType::StopSending
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
-    }
-
     fn max_encoding_size(&self) -> usize {
         1 + 8 + 8
     }
@@ -44,7 +31,6 @@ impl super::BeFrame for StopSendingFrame {
     }
 }
 
-// nom parser for STOP_SENDING_FRAME
 pub fn be_stop_sending_frame(input: &[u8]) -> nom::IResult<&[u8], StopSendingFrame> {
     use nom::{combinator::map, sequence::tuple};
     map(

--- a/qbase/src/frame/stream.rs
+++ b/qbase/src/frame/stream.rs
@@ -13,7 +13,6 @@ use std::ops::Range;
 
 use super::BeFrame;
 use crate::{
-    packet::r#type::Type,
     streamid::{be_streamid, StreamId, WriteStreamId},
     util::{DescribeData, WriteData},
     varint::{be_varint, VarInt, WriteVarInt, VARINT_MAX},
@@ -36,18 +35,6 @@ const FIN_BIT: u8 = 0x01;
 impl BeFrame for StreamFrame {
     fn frame_type(&self) -> super::FrameType {
         super::FrameType::Stream(self.flag)
-    }
-
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
     }
 
     fn max_encoding_size(&self) -> usize {

--- a/qbase/src/frame/stream_data_blocked.rs
+++ b/qbase/src/frame/stream_data_blocked.rs
@@ -5,7 +5,6 @@
 // }
 
 use crate::{
-    packet::r#type::Type,
     streamid::{be_streamid, StreamId, WriteStreamId},
     varint::{be_varint, VarInt, WriteVarInt},
 };
@@ -27,24 +26,11 @@ impl super::BeFrame for StreamDataBlockedFrame {
         1 + 8 + 8
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
-    }
-
     fn encoding_size(&self) -> usize {
         1 + self.stream_id.encoding_size() + self.maximum_stream_data.encoding_size()
     }
 }
 
-// nom parser for STREAM_DATA_BLOCKED_FRAME
 pub fn be_stream_data_blocked_frame(input: &[u8]) -> nom::IResult<&[u8], StreamDataBlockedFrame> {
     let (input, stream_id) = be_streamid(input)?;
     let (input, maximum_stream_data) = be_varint(input)?;

--- a/qbase/src/frame/streams_blocked.rs
+++ b/qbase/src/frame/streams_blocked.rs
@@ -3,10 +3,7 @@
 //   Maximum Streams (i),
 // }
 
-use crate::{
-    packet::r#type::Type,
-    streamid::{be_streamid, Dir, StreamId, WriteStreamId},
-};
+use crate::streamid::{be_streamid, Dir, StreamId, WriteStreamId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamsBlockedFrame {
@@ -26,18 +23,6 @@ impl super::BeFrame for StreamsBlockedFrame {
         })
     }
 
-    fn belongs_to(&self, packet_type: Type) -> bool {
-        use crate::packet::r#type::{
-            long::{Type::V1, Ver1},
-            short::OneRtt,
-        };
-        // __01
-        matches!(
-            packet_type,
-            Type::Long(V1(Ver1::ZERO_RTT)) | Type::Short(OneRtt(_))
-        )
-    }
-
     fn max_encoding_size(&self) -> usize {
         1 + 8
     }
@@ -50,7 +35,6 @@ impl super::BeFrame for StreamsBlockedFrame {
     }
 }
 
-// nom parser for STREAMS_BLOCKED_FRAME
 pub fn streams_blocked_frame_with_dir(
     dir: u8,
 ) -> impl Fn(&[u8]) -> nom::IResult<&[u8], StreamsBlockedFrame> {

--- a/qbase/src/packet/keys.rs
+++ b/qbase/src/packet/keys.rs
@@ -133,8 +133,8 @@ impl OneRttPacketKeys {
 
     /// Get the remote key to decrypt the incoming packet.
     /// If the key phase is not the current key phase, update the key.
-    /// Returning Arc<PacketKey> is to encrypt and decrypt packets at the same time.
-    /// Compared to &'a PacketKey, Arc<PacketKey> does not occupy mutable borrowing &mut self.
+    /// Returning `Arc<PacketKey>` is to encrypt and decrypt packets at the same time.
+    /// Compared to &'a PacketKey, `Arc<PacketKey>` does not occupy mutable borrowing &mut self.
     pub fn get_remote(&mut self, key_phase: KeyPhaseBit, _pn: u64) -> Arc<dyn PacketKey> {
         if key_phase != self.cur_key_phase && self.remote[key_phase.as_index()].is_none() {
             self.update();
@@ -143,8 +143,8 @@ impl OneRttPacketKeys {
     }
 
     /// Get the local key with the current key phase to encrypt the outgoing packet.
-    /// Returning Arc<PacketKey> is to encrypt and decrypt packets at the same time.
-    /// Compared to &'a PacketKey, Arc<PacketKey> does not occupy mutable borrowing &mut self.
+    /// Returning `Arc<PacketKey>` is to encrypt and decrypt packets at the same time.
+    /// Compared to &'a PacketKey, `Arc<PacketKey>` does not occupy mutable borrowing &mut self.
     pub fn get_local(&self) -> (KeyPhaseBit, Arc<dyn PacketKey>) {
         (self.cur_key_phase, self.local.clone())
     }

--- a/qbase/src/packet/type.rs
+++ b/qbase/src/packet/type.rs
@@ -5,7 +5,7 @@ use super::{error::Error, KeyPhaseBit, PacketNumber};
 pub mod long;
 pub mod short;
 
-/// header form bit
+/// Header form bit
 const HEADER_FORM_MASK: u8 = 0x80;
 /// The next bit (0x40) of byte 0 is set to 1, unless the packet is a Version Negotiation packet.
 const FIXED_BIT: u8 = 0x40;


### PR DESCRIPTION
Remove the belongs_to method from the BeFrame trait as it is redundant.
The packet type is already checked when parsing the packet header.
The frame type itself determines which packet types it can belong to.
This simplification removes duplicate logic and improves code clarity.

Additionally, improved documentation and comments for various frame types and methods, including AckFrame, EcnCounts, ConnectionCloseFrame, and others, to enhance understanding and maintainability.