### PR TITLE
refactor(qbase): makes WriteFrame implementations less general

### DIFF
--- a/qbase/Cargo.toml
+++ b/qbase/Cargo.toml
@@ -19,4 +19,4 @@ rustls = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/qbase/src/frame.rs
+++ b/qbase/src/frame.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, BufMut, Bytes};
+use bytes::{Buf, Bytes};
 use enum_dispatch::enum_dispatch;
 use io::WriteFrame;
 
@@ -463,7 +463,7 @@ impl Iterator for FrameReader {
     }
 }
 
-impl<T: BufMut> WriteFrame<StreamCtlFrame> for T {
+impl WriteFrame<StreamCtlFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &StreamCtlFrame) {
         match frame {
             StreamCtlFrame::ResetStream(frame) => self.put_frame(frame),
@@ -476,7 +476,7 @@ impl<T: BufMut> WriteFrame<StreamCtlFrame> for T {
     }
 }
 
-impl<T: BufMut> WriteFrame<ReliableFrame> for T {
+impl WriteFrame<ReliableFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &ReliableFrame) {
         match frame {
             ReliableFrame::NewToken(frame) => self.put_frame(frame),

--- a/qbase/src/frame/data_blocked.rs
+++ b/qbase/src/frame/data_blocked.rs
@@ -39,8 +39,9 @@ pub fn be_data_blocked_frame(input: &[u8]) -> nom::IResult<&[u8], DataBlockedFra
     map(be_varint, |limit| DataBlockedFrame { limit })(input)
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<DataBlockedFrame> for T {
+impl super::io::WriteFrame<DataBlockedFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &DataBlockedFrame) {
+        use bytes::BufMut;
         self.put_u8(DATA_BLOCKED_FRAME_TYPE);
         self.put_varint(&frame.limit);
     }
@@ -66,8 +67,8 @@ mod tests {
 
     #[test]
     fn test_write_data_blocked_frame() {
-        let mut buf = Vec::new();
-        buf.put_frame(&DataBlockedFrame {
+        let mut buf = vec![0; 3];
+        buf.as_mut_slice().put_frame(&DataBlockedFrame {
             limit: crate::varint::VarInt::from_u32(0x1234),
         });
         assert_eq!(buf, vec![DATA_BLOCKED_FRAME_TYPE, 0x52, 0x34]);

--- a/qbase/src/frame/handshake_done.rs
+++ b/qbase/src/frame/handshake_done.rs
@@ -26,8 +26,9 @@ pub fn be_handshake_done_frame(input: &[u8]) -> nom::IResult<&[u8], HandshakeDon
     Ok((input, HandshakeDoneFrame))
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<HandshakeDoneFrame> for T {
+impl super::io::WriteFrame<HandshakeDoneFrame> for &mut [u8] {
     fn put_frame(&mut self, _: &HandshakeDoneFrame) {
+        use bytes::BufMut;
         self.put_u8(HANDSHAKE_DONE_FRAME_TYPE);
     }
 }
@@ -57,8 +58,8 @@ mod tests {
 
     #[test]
     fn test_write_handshake_done_frame() {
-        let mut buf = Vec::new();
-        buf.put_frame(&HandshakeDoneFrame);
-        assert_eq!(buf, vec![super::HANDSHAKE_DONE_FRAME_TYPE]);
+        let mut buf = [0u8; 1];
+        buf.as_mut().put_frame(&HandshakeDoneFrame);
+        assert_eq!(buf, [super::HANDSHAKE_DONE_FRAME_TYPE]);
     }
 }

--- a/qbase/src/frame/max_data.rs
+++ b/qbase/src/frame/max_data.rs
@@ -39,8 +39,9 @@ pub fn be_max_data_frame(input: &[u8]) -> nom::IResult<&[u8], MaxDataFrame> {
     map(be_varint, |max_data| MaxDataFrame { max_data })(input)
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<MaxDataFrame> for T {
+impl super::io::WriteFrame<MaxDataFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &MaxDataFrame) {
+        use bytes::BufMut;
         self.put_u8(MAX_DATA_FRAME_TYPE);
         self.put_varint(&frame.max_data);
     }
@@ -77,10 +78,10 @@ mod tests {
 
     #[test]
     fn test_write_max_data_frame() {
-        let mut buf = Vec::new();
-        buf.put_frame(&MaxDataFrame {
+        let mut buf = [0; 3];
+        buf.as_mut().put_frame(&MaxDataFrame {
             max_data: VarInt::from_u32(0x1234),
         });
-        assert_eq!(buf, vec![MAX_DATA_FRAME_TYPE, 0x52, 0x34]);
+        assert_eq!(buf, [MAX_DATA_FRAME_TYPE, 0x52, 0x34]);
     }
 }

--- a/qbase/src/frame/max_stream_data.rs
+++ b/qbase/src/frame/max_stream_data.rs
@@ -60,8 +60,9 @@ pub fn be_max_stream_data_frame(input: &[u8]) -> nom::IResult<&[u8], MaxStreamDa
     )(input)
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<MaxStreamDataFrame> for T {
+impl super::io::WriteFrame<MaxStreamDataFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &MaxStreamDataFrame) {
+        use bytes::BufMut;
         self.put_u8(MAX_STREAM_DATA_FRAME_TYPE);
         self.put_streamid(&frame.stream_id);
         self.put_varint(&frame.max_stream_data);
@@ -84,14 +85,14 @@ mod tests {
 
     #[test]
     fn test_write_max_stream_data_frame() {
-        let mut buf = Vec::new();
-        buf.put_frame(&MaxStreamDataFrame {
+        let mut buf = [0; 7];
+        buf.as_mut().put_frame(&MaxStreamDataFrame {
             stream_id: VarInt::from_u32(0x1234).into(),
             max_stream_data: VarInt::from_u32(0x5678),
         });
         assert_eq!(
             buf,
-            vec![MAX_STREAM_DATA_FRAME_TYPE, 0x52, 0x34, 0x80, 0, 0x56, 0x78]
+            [MAX_STREAM_DATA_FRAME_TYPE, 0x52, 0x34, 0x80, 0, 0x56, 0x78]
         );
     }
 }

--- a/qbase/src/frame/max_streams.rs
+++ b/qbase/src/frame/max_streams.rs
@@ -79,8 +79,9 @@ pub fn max_streams_frame_with_dir(
     }
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<MaxStreamsFrame> for T {
+impl super::io::WriteFrame<MaxStreamsFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &MaxStreamsFrame) {
+        use bytes::BufMut;
         match frame {
             MaxStreamsFrame::Bi(max_streams) => {
                 self.put_u8(MAX_STREAMS_FRAME_TYPE);
@@ -165,11 +166,14 @@ mod tests {
 
     #[test]
     fn test_write_max_streams_frame() {
-        let mut buf = Vec::new();
-        buf.put_frame(&MaxStreamsFrame::Bi(VarInt::from_u32(0x1234)));
-        assert_eq!(buf, vec![MAX_STREAMS_FRAME_TYPE, 0x52, 0x34]);
-        buf.clear();
-        buf.put_frame(&MaxStreamsFrame::Uni(VarInt::from_u32(0x1236)));
-        assert_eq!(buf, vec![0x13, 0x52, 0x36]);
+        let mut buf = [0; 3];
+        buf.as_mut()
+            .put_frame(&MaxStreamsFrame::Bi(VarInt::from_u32(0x1234)));
+        assert_eq!(buf, [MAX_STREAMS_FRAME_TYPE, 0x52, 0x34]);
+
+        let mut buf = [0; 3];
+        buf.as_mut()
+            .put_frame(&MaxStreamsFrame::Uni(VarInt::from_u32(0x1236)));
+        assert_eq!(buf, [0x13, 0x52, 0x36]);
     }
 }

--- a/qbase/src/frame/new_connection_id.rs
+++ b/qbase/src/frame/new_connection_id.rs
@@ -94,8 +94,9 @@ pub fn be_new_connection_id_frame(input: &[u8]) -> nom::IResult<&[u8], NewConnec
     ))
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<NewConnectionIdFrame> for T {
+impl super::io::WriteFrame<NewConnectionIdFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &NewConnectionIdFrame) {
+        use bytes::BufMut;
         self.put_u8(NEW_CONNECTION_ID_FRAME_TYPE);
         self.put_varint(&frame.sequence);
         self.put_varint(&frame.retire_prior_to);

--- a/qbase/src/frame/new_token.rs
+++ b/qbase/src/frame/new_token.rs
@@ -50,8 +50,9 @@ pub fn be_new_token_frame(input: &[u8]) -> nom::IResult<&[u8], NewTokenFrame> {
     })(input)
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<NewTokenFrame> for T {
+impl super::io::WriteFrame<NewTokenFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &NewTokenFrame) {
+        use bytes::BufMut;
         self.put_u8(NEW_TOKEN_FRAME_TYPE);
         self.put_varint(&VarInt::from_u32(frame.token.len() as u32));
         self.put_slice(&frame.token);
@@ -72,11 +73,11 @@ mod tests {
 
     #[test]
     fn test_write_new_token_frame() {
-        let mut buf = Vec::<u8>::new();
+        let mut buf = [0; 4];
         let frame = super::NewTokenFrame {
             token: vec![0x01, 0x02],
         };
-        buf.put_frame(&frame);
-        assert_eq!(buf, vec![0x07, 0x02, 0x01, 0x02]);
+        buf.as_mut().put_frame(&frame);
+        assert_eq!(buf, [0x07, 0x02, 0x01, 0x02]);
     }
 }

--- a/qbase/src/frame/padding.rs
+++ b/qbase/src/frame/padding.rs
@@ -26,8 +26,9 @@ pub fn be_padding_frame(input: &[u8]) -> nom::IResult<&[u8], PaddingFrame> {
     Ok((input, PaddingFrame))
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<PaddingFrame> for T {
+impl super::io::WriteFrame<PaddingFrame> for &mut [u8] {
     fn put_frame(&mut self, _: &PaddingFrame) {
+        use bytes::BufMut;
         self.put_u8(PADDING_FRAME_TYPE);
     }
 }
@@ -58,8 +59,8 @@ mod tests {
 
     #[test]
     fn test_write_padding_frame() {
-        let mut buf = Vec::new();
-        buf.put_frame(&PaddingFrame);
-        assert_eq!(buf, vec![PADDING_FRAME_TYPE]);
+        let mut buf = [0; 1];
+        buf.as_mut().put_frame(&PaddingFrame);
+        assert_eq!(buf, [PADDING_FRAME_TYPE]);
     }
 }

--- a/qbase/src/frame/path_challenge.rs
+++ b/qbase/src/frame/path_challenge.rs
@@ -57,8 +57,9 @@ pub fn be_path_challenge_frame(input: &[u8]) -> nom::IResult<&[u8], PathChalleng
 }
 
 // BufMut write extension for PATH_CHALLENGE_FRAME
-impl<T: bytes::BufMut> super::io::WriteFrame<PathChallengeFrame> for T {
+impl super::io::WriteFrame<PathChallengeFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &PathChallengeFrame) {
+        use bytes::BufMut;
         self.put_u8(PATH_CHALLENGE_FRAME_TYPE);
         self.put_slice(&frame.data);
     }
@@ -103,14 +104,14 @@ mod tests {
     #[test]
     fn test_write_path_challenge_frame() {
         use crate::frame::io::WriteFrame;
-        let mut buf = Vec::new();
+        let mut buf = [0; 9];
         let frame = super::PathChallengeFrame {
             data: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
         };
-        buf.put_frame(&frame);
+        buf.as_mut().put_frame(&frame);
         assert_eq!(
             buf,
-            vec![
+            [
                 super::PATH_CHALLENGE_FRAME_TYPE,
                 0x01,
                 0x02,

--- a/qbase/src/frame/path_response.rs
+++ b/qbase/src/frame/path_response.rs
@@ -57,8 +57,9 @@ pub fn be_path_response_frame(input: &[u8]) -> nom::IResult<&[u8], PathResponseF
     map(take(8usize), PathResponseFrame::from_slice)(input)
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<PathResponseFrame> for T {
+impl super::io::WriteFrame<PathResponseFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &PathResponseFrame) {
+        use bytes::BufMut;
         self.put_u8(PATH_RESPONSE_FRAME_TYPE);
         self.put_slice(&frame.data);
     }
@@ -103,14 +104,14 @@ mod tests {
     #[test]
     fn test_write_path_response_frame() {
         use crate::frame::io::WriteFrame;
-        let mut buf = Vec::<u8>::new();
+        let mut buf = [0; 9];
         let frame = super::PathResponseFrame {
             data: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
         };
-        buf.put_frame(&frame);
+        buf.as_mut().put_frame(&frame);
         assert_eq!(
             buf,
-            vec![
+            [
                 super::PATH_RESPONSE_FRAME_TYPE,
                 0x01,
                 0x02,

--- a/qbase/src/frame/ping.rs
+++ b/qbase/src/frame/ping.rs
@@ -26,8 +26,9 @@ pub fn be_ping_frame(input: &[u8]) -> nom::IResult<&[u8], PingFrame> {
     Ok((input, PingFrame))
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<PingFrame> for T {
+impl super::io::WriteFrame<PingFrame> for &mut [u8] {
     fn put_frame(&mut self, _: &PingFrame) {
+        use bytes::BufMut;
         self.put_u8(PING_FRAME_TYPE);
     }
 }
@@ -57,8 +58,8 @@ mod tests {
 
     #[test]
     fn test_write_ping_frame() {
-        let mut buf = Vec::new();
-        buf.put_frame(&PingFrame);
-        assert_eq!(buf, vec![PING_FRAME_TYPE]);
+        let mut buf = [0; 1];
+        buf.as_mut().put_frame(&PingFrame);
+        assert_eq!(buf, [PING_FRAME_TYPE]);
     }
 }

--- a/qbase/src/frame/retire_connection_id.rs
+++ b/qbase/src/frame/retire_connection_id.rs
@@ -39,8 +39,9 @@ pub fn be_retire_connection_id_frame(input: &[u8]) -> nom::IResult<&[u8], Retire
     map(be_varint, |sequence| RetireConnectionIdFrame { sequence })(input)
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<RetireConnectionIdFrame> for T {
+impl super::io::WriteFrame<RetireConnectionIdFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &RetireConnectionIdFrame) {
+        use bytes::BufMut;
         self.put_u8(RETIRE_CONNECTION_ID_FRAME_TYPE);
         self.put_varint(&frame.sequence);
     }
@@ -66,11 +67,11 @@ mod tests {
 
     #[test]
     fn test_write_retire_connection_id_frame() {
-        let mut buf = Vec::new();
+        let mut buf = [0; 3];
         let frame = RetireConnectionIdFrame {
             sequence: VarInt::from_u32(0x1234),
         };
-        buf.put_frame(&frame);
-        assert_eq!(buf, vec![0x19, 0x52, 0x34]);
+        buf.as_mut().put_frame(&frame);
+        assert_eq!(buf, [0x19, 0x52, 0x34]);
     }
 }

--- a/qbase/src/frame/stream_data_blocked.rs
+++ b/qbase/src/frame/stream_data_blocked.rs
@@ -51,8 +51,9 @@ pub fn be_stream_data_blocked_frame(input: &[u8]) -> nom::IResult<&[u8], StreamD
     ))
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<StreamDataBlockedFrame> for T {
+impl super::io::WriteFrame<StreamDataBlockedFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &StreamDataBlockedFrame) {
+        use bytes::BufMut;
         self.put_u8(STREAM_DATA_BLOCKED_FRAME_TYPE);
         self.put_streamid(&frame.stream_id);
         self.put_varint(&frame.maximum_stream_data);
@@ -80,14 +81,14 @@ mod tests {
 
     #[test]
     fn test_write_stream_data_blocked_frame() {
-        let mut buf = Vec::new();
-        buf.put_frame(&StreamDataBlockedFrame {
+        let mut buf = [0; 7];
+        buf.as_mut().put_frame(&StreamDataBlockedFrame {
             stream_id: VarInt::from_u32(0x1234).into(),
             maximum_stream_data: VarInt::from_u32(0x5678),
         });
         assert_eq!(
             buf,
-            vec![
+            [
                 STREAM_DATA_BLOCKED_FRAME_TYPE,
                 0x52,
                 0x34,

--- a/qbase/src/frame/streams_blocked.rs
+++ b/qbase/src/frame/streams_blocked.rs
@@ -71,8 +71,9 @@ pub fn streams_blocked_frame_with_dir(
     }
 }
 
-impl<T: bytes::BufMut> super::io::WriteFrame<StreamsBlockedFrame> for T {
+impl super::io::WriteFrame<StreamsBlockedFrame> for &mut [u8] {
     fn put_frame(&mut self, frame: &StreamsBlockedFrame) {
+        use bytes::BufMut;
         match frame {
             StreamsBlockedFrame::Bi(max_streams) => {
                 self.put_u8(STREAMS_BLOCKED_FRAME_TYPE);
@@ -125,12 +126,14 @@ mod tests {
 
     #[test]
     fn test_write_streams_blocked_frame() {
-        let mut buf = Vec::new();
-        buf.put_frame(&StreamsBlockedFrame::Bi(VarInt::from_u32(0x1234)));
-        assert_eq!(buf, vec![STREAMS_BLOCKED_FRAME_TYPE, 0x52, 0x34]);
+        let mut buf = [0; 3];
+        buf.as_mut()
+            .put_frame(&StreamsBlockedFrame::Bi(VarInt::from_u32(0x1234)));
+        assert_eq!(buf, [STREAMS_BLOCKED_FRAME_TYPE, 0x52, 0x34]);
 
-        let mut buf = Vec::new();
-        buf.put_frame(&StreamsBlockedFrame::Uni(VarInt::from_u32(0x1234)));
-        assert_eq!(buf, vec![STREAMS_BLOCKED_FRAME_TYPE + 1, 0x52, 0x34]);
+        let mut buf = [0; 3];
+        buf.as_mut()
+            .put_frame(&StreamsBlockedFrame::Uni(VarInt::from_u32(0x1234)));
+        assert_eq!(buf, [STREAMS_BLOCKED_FRAME_TYPE + 1, 0x52, 0x34]);
     }
 }

--- a/quic/src/client.rs
+++ b/quic/src/client.rs
@@ -279,7 +279,6 @@ impl<T> QuicClientBuilder<T> {
 
     /// Enable reuse UDP sockets.
     ///
-    ///
     /// By default, the client will not use the same address as other connections, which means that the client must bind
     /// to a new address every time it initiates a connection. If you enable this option, the client cloud share the same
     /// address with other connections. This option can only determine the behavior of this client when establishing a
@@ -421,7 +420,7 @@ impl QuicClientBuilder<TlsClientConfigBuilder<WantsClientCert>> {
         cert_chain_file: impl AsRef<Path>,
         key_file: impl AsRef<Path>,
     ) -> io::Result<QuicClientBuilder<TlsClientConfig>> {
-        let (cert_chain, key_der) = util::parse_cert_files(cert_chain_file, key_file)?;
+        let (cert_chain, key_der) = util::parse_pem_files(cert_chain_file, key_file)?;
         Ok(self.with_cert(cert_chain, key_der))
     }
 

--- a/quic/src/server.rs
+++ b/quic/src/server.rs
@@ -403,7 +403,7 @@ impl QuicServerBuilder<TlsServerConfigBuilder<WantsServerCert>> {
         }
     }
 
-    /// Add a host with a certificate chain and a private key from cert files.
+    /// Add a host with a certificate chain and a private key from cert files in pem format.
     ///
     /// This is a useful wapper of [`QuicServerBuilder::with_single_cert_files`], we do the *pem* file decoding and error
     /// handling for you.
@@ -412,7 +412,7 @@ impl QuicServerBuilder<TlsServerConfigBuilder<WantsServerCert>> {
         cert_chain_file: impl AsRef<std::path::Path>,
         key_file: impl AsRef<std::path::Path>,
     ) -> io::Result<QuicServerBuilder<TlsServerConfig>> {
-        let (cert_chain, key_der) = util::parse_cert_files(cert_chain_file, key_file)?;
+        let (cert_chain, key_der) = util::parse_pem_files(cert_chain_file, key_file)?;
         Ok(self.with_single_cert(cert_chain, key_der))
     }
 
@@ -451,7 +451,7 @@ impl QuicServerBuilder<TlsServerConfigBuilder<WantsServerCert>> {
         key_file: impl AsRef<std::path::Path>,
         ocsp: Vec<u8>,
     ) -> io::Result<QuicServerBuilder<TlsServerConfig>> {
-        let (cert_chain, key_der) = util::parse_cert_files(cert_chain_file, key_file)?;
+        let (cert_chain, key_der) = util::parse_pem_files(cert_chain_file, key_file)?;
         Ok(QuicServerBuilder {
             passive_listening: self.passive_listening,
             supported_versions: self.supported_versions,
@@ -525,7 +525,7 @@ impl QuicServerSniBuilder<TlsServerConfig> {
         cert_chain_file: impl AsRef<std::path::Path>,
         key_file: impl AsRef<std::path::Path>,
     ) -> io::Result<Self> {
-        let (cert_chain, key_der) = util::parse_cert_files(cert_chain_file, key_file)?;
+        let (cert_chain, key_der) = util::parse_pem_files(cert_chain_file, key_file)?;
         Ok(self.add_host(server_name, cert_chain, key_der))
     }
 }

--- a/quic/src/util.rs
+++ b/quic/src/util.rs
@@ -2,7 +2,7 @@ use std::{io, path::Path};
 
 use rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
 
-pub fn parse_cert_files(
+pub fn parse_pem_files(
     cert_chain_file: impl AsRef<Path>,
     key_file: impl AsRef<Path>,
 ) -> io::Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {


### PR DESCRIPTION
计划：
1. 让WriteFrame特征和BufMut稍微区分开来，让PacketWriter可以实现自定义的WriteFrame，WriteDataFrames，做到统计各种信息
2. 区分PacketWriter，分成写Initial，HS，0rtt，1rtt的Writer。为对应Writer实现写对应包类型可以有的帧的WriteFrame特征，具体参照https://www.rfc-editor.org/rfc/rfc9000.html#frame-types
3. 将各种read方法的参数 mut buf: &mut [u8] 改为&mut impl WriteFrame<>，简化填包逻辑