### PR TITLE
refactor: fix edition 2024, improve gm_quic::util

### DIFF
--- a/gm-quic/examples/client.rs
+++ b/gm-quic/examples/client.rs
@@ -27,11 +27,12 @@ struct Arguments {
 fn main() {
     let args = Arguments::parse();
     let code = {
-        if let Err(e) = run(args) {
-            eprintln!("ERROR: {e}");
-            1
-        } else {
-            0
+        match run(args) {
+            Err(e) => {
+                eprintln!("ERROR: {e}");
+                1
+            }
+            _ => 0,
         }
     };
     ::std::process::exit(code);

--- a/gm-quic/examples/server.rs
+++ b/gm-quic/examples/server.rs
@@ -21,11 +21,12 @@ struct Opt {
 fn main() {
     let opt = Opt::parse();
     let code = {
-        if let Err(e) = run(opt) {
-            eprintln!("ERROR: {e}");
-            1
-        } else {
-            0
+        match run(opt) {
+            Err(e) => {
+                eprintln!("ERROR: {e}");
+                1
+            }
+            _ => 0,
         }
     };
     ::std::process::exit(code);
@@ -44,7 +45,7 @@ async fn run(options: Opt) -> Result<(), Box<dyn std::error::Error>> {
         .with_supported_versions([0x00000001u32])
         .without_cert_verifier()
         // .keep_alive()
-        .with_single_cert(options.cert, options.key)
+        .with_single_cert(options.cert.as_path(), options.key.as_path())
         .listen(options.bind)?;
 
     while let Ok((_conn, pathway)) = server.accept().await {

--- a/h3-shim/examples/h3-server.rs
+++ b/h3-shim/examples/h3-server.rs
@@ -95,7 +95,7 @@ pub async fn run(opt: Opt) -> Result<(), Box<dyn std::error::Error + Send + Sync
         .without_cert_verifier()
         .with_parameters(params)
         .enable_sni()
-        .add_host("localhost", cert, key)
+        .add_host("localhost", cert.as_path(), key.as_path())
         .with_alpns([ALPN.to_vec()])
         .listen(&opt.listen[..])?;
     info!("listening on {:?}", quic_server.addresses());

--- a/qbase/src/util/bound_deque.rs
+++ b/qbase/src/util/bound_deque.rs
@@ -105,12 +105,15 @@ impl<T> futures::Stream for Receiver<T> {
         if queue.capacity() == 0 {
             return Poll::Ready(None);
         }
-        if let Some(item) = queue.pop_front() {
-            self.inner.write_waker.wake();
-            Poll::Ready(Some(item))
-        } else {
-            self.inner.read_waker.register(cx.waker());
-            Poll::Pending
+        match queue.pop_front() {
+            Some(item) => {
+                self.inner.write_waker.wake();
+                Poll::Ready(Some(item))
+            }
+            _ => {
+                self.inner.read_waker.register(cx.waker());
+                Poll::Pending
+            }
         }
     }
 }

--- a/qconnection/src/builder.rs
+++ b/qconnection/src/builder.rs
@@ -419,7 +419,7 @@ impl ComponentsReady {
     }
 }
 
-fn accpet_transport_parameters(components: &Components) -> impl Future<Output = ()> + Send {
+fn accpet_transport_parameters(components: &Components) -> impl Future<Output = ()> + Send + use<> {
     let params = components.parameters.clone();
     let streams = components.spaces.data().streams().clone();
     let cid_registry = components.cid_registry.clone();

--- a/qconnection/src/lib.rs
+++ b/qconnection/src/lib.rs
@@ -175,7 +175,7 @@ pub struct Components {
 impl Components {
     pub fn open_bi_stream(
         &self,
-    ) -> impl Future<Output = io::Result<Option<(StreamId, (StreamReader, StreamWriter))>>> + Send
+    ) -> impl Future<Output = io::Result<Option<(StreamId, (StreamReader, StreamWriter))>>> + Send + use<>
     {
         let params = self.parameters.clone();
         let streams = self.spaces.data().streams().clone();
@@ -193,7 +193,7 @@ impl Components {
 
     pub fn open_uni_stream(
         &self,
-    ) -> impl Future<Output = io::Result<Option<(StreamId, StreamWriter)>>> + Send {
+    ) -> impl Future<Output = io::Result<Option<(StreamId, StreamWriter)>>> + Send + use<> {
         let params = self.parameters.clone();
         let streams = self.spaces.data().streams().clone();
         let send_notify = self.send_notify.clone();
@@ -209,7 +209,7 @@ impl Components {
 
     pub fn accept_bi_stream(
         &self,
-    ) -> impl Future<Output = io::Result<Option<(StreamId, (StreamReader, StreamWriter))>>> + Send
+    ) -> impl Future<Output = io::Result<Option<(StreamId, (StreamReader, StreamWriter))>>> + Send + use<>
     {
         let params = self.parameters.clone();
         let streams = self.spaces.data().streams().clone();
@@ -227,7 +227,7 @@ impl Components {
 
     pub fn accept_uni_stream(
         &self,
-    ) -> impl Future<Output = io::Result<Option<(StreamId, StreamReader)>>> + Send {
+    ) -> impl Future<Output = io::Result<Option<(StreamId, StreamReader)>>> + Send + use<> {
         let streams = self.spaces.data().streams().clone();
         async move { Ok(Some(streams.accept_uni().await?)) }
     }
@@ -236,7 +236,9 @@ impl Components {
         self.spaces.data().datagrams().reader()
     }
 
-    pub fn unreliable_writer(&self) -> impl Future<Output = io::Result<UnreliableWriter>> + Send {
+    pub fn unreliable_writer(
+        &self,
+    ) -> impl Future<Output = io::Result<UnreliableWriter>> + Send + use<> {
         let params = self.parameters.clone();
         let datagrams = self.spaces.data().datagrams().clone();
         async move {

--- a/qconnection/src/path/burst.rs
+++ b/qconnection/src/path/burst.rs
@@ -48,7 +48,7 @@ impl Burst {
     fn prepare_buffers<'b>(
         &self,
         buffers: &'b mut Vec<Vec<u8>>,
-    ) -> io::Result<impl Iterator<Item = &'b mut [u8]>> {
+    ) -> io::Result<impl Iterator<Item = &'b mut [u8]> + use<'b>> {
         let max_segments = self.path.interface.max_segments()?;
         let max_segment_size = self.path.interface.max_segment_size()?;
 

--- a/qconnection/src/path/idle.rs
+++ b/qconnection/src/path/idle.rs
@@ -19,7 +19,10 @@ impl super::Path {
         }
     }
 
-    pub fn idle_timeout(self: &Arc<Self>, components: &Components) -> impl Future<Output = ()> {
+    pub fn idle_timeout(
+        self: &Arc<Self>,
+        components: &Components,
+    ) -> impl Future<Output = ()> + use<> {
         let parameters = components.parameters.clone();
         let this = self.clone();
         async move {

--- a/qconnection/src/tls.rs
+++ b/qconnection/src/tls.rs
@@ -215,7 +215,7 @@ impl ArcTlsSession {
 
 /// Start the TLS handshake, automatically upgrade the keys, and transmit tls data.
 #[tracing::instrument(level = "trace", skip(components))]
-pub fn keys_upgrade(components: &Components) -> impl Future<Output = ()> + Send {
+pub fn keys_upgrade(components: &Components) -> impl Future<Output = ()> + Send + use<> {
     let crypto_streams: [&CryptoStream; 3] = [
         components.spaces.initial().crypto_stream(),
         components.spaces.handshake().crypto_stream(),

--- a/qrecovery/src/journal/sent.rs
+++ b/qrecovery/src/journal/sent.rs
@@ -212,12 +212,12 @@ impl<T: Clone> RotateGuard<'_, T> {
     }
 
     /// Called when the packet sent is acked by peer, return the frames in that packet.
-    pub fn on_pkt_acked(&mut self, pn: u64) -> impl Iterator<Item = T> + '_ {
+    pub fn on_pkt_acked(&mut self, pn: u64) -> impl Iterator<Item = T> + '_ + use<'_, T> {
         self.inner.on_pkt_acked(pn)
     }
 
     /// Called when the packet sent may lost, reutrn the frames in that packet.
-    pub fn may_loss_pkt(&mut self, pn: u64) -> impl Iterator<Item = T> + '_ {
+    pub fn may_loss_pkt(&mut self, pn: u64) -> impl Iterator<Item = T> + '_ + use<'_, T> {
         self.inner.may_loss_pkt(pn)
     }
 


### PR DESCRIPTION
只接受Path不够好用，如果我要include_bytes!()，或者自己读取文件，或者比如从数据库读密钥l...还得手动去做解析

而泛型特化稳定遥遥无期，，所以将impl<P: AsRef<Path>> ToXXX for P 改为 impl ToXXX for &Path，对外界调用者来说就加一串`.as_ref`和`as_path()`的事

然后，就可以加上impl ToXXX for &[u8]

然后另一个改动就是运行了`cargo fix --edition`，2024版已经进了beta，快了

看了下改动，rust2024改了RTIP的自动捕获规则以和async fn保持一致。一些方法结尾都得加上use手动捕获，才可以保证未来可以编译通过

再就是2024会改临时变量的drop顺序（比如if let的），对我们的代码没有影响。自动修复把很多if let改成了match，其实没必要，有一部分改回来保持代码美观

再就是宏也更新，expr变成expr_2021，不该应该也不会有事，也就没跟随自动修复