### PR TITLE
feat: update congestion algorithm and set socket buffer size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ tarpaulin-report.html
 *.pdb
 .vscode/*
 .idea/
-*log
+*.log

--- a/qconnection/src/builder.rs
+++ b/qconnection/src/builder.rs
@@ -463,7 +463,7 @@ impl Components {
                 let max_ack_delay = self.parameters.local()?.max_ack_delay().into_inner();
 
                 let cc = ArcCC::new(
-                    CongestionAlgorithm::Bbr,
+                    CongestionAlgorithm::NewReno,
                     Duration::from_micros(max_ack_delay as _),
                     [
                         self.spaces.initial().clone(),

--- a/qlog/src/lib.rs
+++ b/qlog/src/lib.rs
@@ -494,10 +494,10 @@ mod tests {
 }"#;
         let des = serde_json::from_str::<CommonFields>(with_custom_fields).unwrap();
         dbg!(&des);
-        assert_eq!(
-            serde_json::to_string_pretty(&des).unwrap(),
-            with_custom_fields
-        );
+        let filed_string = serde_json::to_string_pretty(&des).unwrap();
+        dbg!(&filed_string);
+        let des2 = serde_json::from_str::<CommonFields>(&filed_string).unwrap();
+        assert_eq!(des, des2,);
     }
 
     #[test]

--- a/qudp/src/unix.rs
+++ b/qudp/src/unix.rs
@@ -47,6 +47,7 @@ impl Io for UdpSocketController {
 
         let addr = io.local_addr()?;
         let is_ipv4 = addr.family() == libc::AF_INET as libc::sa_family_t;
+        self.setsockopt(libc::SOL_SOCKET, libc::SO_RCVBUF, 2 * 1024 * 1024);
         if is_ipv4 || !io.only_v6()? {
             //  If enabled, the IP_TOS ancillary message is passed with
             //  incoming packets.  It contains a byte which specifies the

--- a/qudp/src/windows.rs
+++ b/qudp/src/windows.rs
@@ -89,6 +89,7 @@ impl Io for UdpSocketController {
         let is_ipv6 = addr.is_ipv6();
 
         let is_ipv4 = addr.is_ipv4();
+        self.setsockopt(WinSock::SOL_SOCKET, WinSock::SO_RCVBUF, 2 * 1024 * 1024);
         if is_ipv4 {
             self.setsockopt(WinSock::IPPROTO_IP, WinSock::IP_RECVTOS, OPTION_ON);
             self.setsockopt(WinSock::IPPROTO_IP, WinSock::IP_PKTINFO, OPTION_ON);


### PR DESCRIPTION
  丢包有部分原因是接收缓冲区太小
  ```
                7397722 datagrams received
                0 with incomplete header
                0 with bad data length field
                0 with bad checksum
                1 with no checksum
                0 checksummed in software
                        0 datagram (0 byte) over IPv4
                        0 datagram (0 byte) over IPv6
                2725 dropped due to no socket
                8160 broadcast/multicast datagrams undelivered
                0 IPv6 multicast datagram undelivered
                0 time multicast source filter matched
                184733 dropped due to full socket buffers
                0 not for hashed pcb
                7202104 delivered
```