### PR TITLE
feat: add an interface for obtaining origin_dcid

### DIFF
--- a/qconnection/src/builder.rs
+++ b/qconnection/src/builder.rs
@@ -1,5 +1,6 @@
 use std::{
     future::Future,
+    io,
     sync::{Arc, RwLock},
     time::Duration,
 };
@@ -313,7 +314,6 @@ impl ProtoReady<ServerFoundation, Arc<rustls::ServerConfig>> {
         original_dcid: ConnectionId,
         client_scid: ConnectionId,
     ) -> ComponentsReady {
-        let server_params = &mut self.foundation.server_params;
         let tx_wakers = ArcSendWakers::default();
         let reliable_frames = ArcReliableFrameDeque::with_capacity_and_wakers(8, tx_wakers.clone());
 
@@ -323,6 +323,7 @@ impl ProtoReady<ServerFoundation, Arc<rustls::ServerConfig>> {
         let router_registry: qinterface::router::RouterRegistry<ArcReliableFrameDeque> =
             self.proto.registry(rcvd_pkt_q.clone(), issued_cids);
 
+        let server_params = &mut self.foundation.server_params;
         let initial_scid = router_registry.gen_unique_cid();
         server_params.set_initial_source_connection_id(initial_scid);
 
@@ -470,14 +471,24 @@ fn accpet_transport_parameters(components: &Components) -> impl Future<Output = 
         use qbase::frame::{MaxStreamsFrame, ReceiveFrame, StreamCtlFrame};
         if let Ok(param::Pair { remote, .. }) = params.clone().await {
             match role {
-                sid::Role::Client => qlog::event!(ParametersSet {
-                    owner: Owner::Remote,
-                    server_parameters: params.server().expect("unreachable"),
-                }),
-                sid::Role::Server => qlog::event!(ParametersSet {
-                    owner: Owner::Local,
-                    client_parameters: params.client().expect("unreachable"),
-                }),
+                sid::Role::Client => {
+                    let Ok(server_parameters) = params.server() else {
+                        return;
+                    };
+                    qlog::event!(ParametersSet {
+                        owner: Owner::Remote,
+                        server_parameters: server_parameters.expect("unreachable"),
+                    })
+                }
+                sid::Role::Server => {
+                    let Ok(client_parameters) = params.client() else {
+                        return;
+                    };
+                    qlog::event!(ParametersSet {
+                        owner: Owner::Remote,
+                        client_parameters: client_parameters.expect("unreachable"),
+                    })
+                }
             }
 
             // pretend to receive the MAX_STREAM frames
@@ -506,9 +517,9 @@ impl Components {
         link: Link,
         pathway: Pathway,
         is_probed: bool,
-    ) -> Option<Arc<Path>> {
+    ) -> io::Result<Arc<Path>> {
         self.paths.get_or_try_create_with (pathway,||{
-                let do_validate = !self.state.try_entry_attempted(self, link);
+                let do_validate = !self.state.try_entry_attempted(self, link)?;
                 qlog::event!(PathAssigned {
                     path_id: pathway.to_string(),
                     path_local: link.src(),
@@ -565,7 +576,7 @@ impl Components {
                         .instrument_in_current();
 
                 tracing::info!(%pathway, %link,is_probed,do_validate, "created new path");
-                Some((path,task))
+                Ok((path,task))
         })
     }
 }
@@ -587,7 +598,7 @@ impl Components {
         self.flow_ctrl.on_conn_error(&error);
         self.tls_session.on_conn_error(&error);
         if self.handshake.role() == sid::Role::Server {
-            let local_parameters = self.parameters.server().unwrap();
+            let local_parameters = self.parameters.server().unwrap().unwrap();
             let origin_dcid = local_parameters.original_destination_connection_id();
             self.proto.del_router_entry(&origin_dcid.into());
         }
@@ -632,7 +643,7 @@ impl Components {
         self.flow_ctrl.on_conn_error(&error);
         self.tls_session.on_conn_error(&error);
         if self.handshake.role() == sid::Role::Server {
-            let local_parameters = self.parameters.server().unwrap();
+            let local_parameters = self.parameters.server().unwrap().unwrap();
             let origin_dcid = local_parameters.original_destination_connection_id();
             self.proto.del_router_entry(&origin_dcid.into());
         }

--- a/qconnection/src/path.rs
+++ b/qconnection/src/path.rs
@@ -43,11 +43,11 @@ pub struct Path {
 }
 
 impl Path {
-    pub fn new(proto: &QuicProto, link: Link, pathway: Pathway, cc: ArcCC) -> Option<Self> {
-        let interface = proto.get_interface(link.src()).ok()?;
+    pub fn new(proto: &QuicProto, link: Link, pathway: Pathway, cc: ArcCC) -> io::Result<Self> {
+        let interface = proto.get_interface(link.src())?;
         let tx_waker = ArcSendWaker::new();
         let handle = cc.launch_with_waker(tx_waker.clone());
-        Some(Self {
+        Ok(Self {
             interface,
             link,
             pathway,

--- a/qconnection/src/space.rs
+++ b/qconnection/src/space.rs
@@ -355,7 +355,7 @@ where
         })
     }
 
-    pub fn emit_received(self, frames: impl Into<Vec<QuicFrame>>) {
+    pub fn emit_received(&self, frames: impl Into<Vec<QuicFrame>>) {
         qlog::event!(PacketReceived {
             header: self.qlog_header(),
             frames,

--- a/qlog/src/quic.rs
+++ b/qlog/src/quic.rs
@@ -276,7 +276,7 @@ impl PacketHeaderBuilder {
             .scil(header.scid().len() as u8)
             .scid(*header.scid())
             .dcil(header.dcid().len() as u8)
-            .scid(*header.dcid())
+            .dcid(*header.dcid())
     }
 
     /// Helper method used to set the fields of the handshake header,
@@ -287,7 +287,7 @@ impl PacketHeaderBuilder {
             .scil(header.scid().len() as u8)
             .scid(*header.scid())
             .dcil(header.dcid().len() as u8)
-            .scid(*header.dcid())
+            .dcid(*header.dcid())
     }
 
     /// Helper method used to set the fields of the 0rtt header,
@@ -298,7 +298,7 @@ impl PacketHeaderBuilder {
             .scil(header.scid().len() as u8)
             .scid(*header.scid())
             .dcil(header.dcid().len() as u8)
-            .scid(*header.dcid())
+            .dcid(*header.dcid())
     }
 
     /// Helper method used to set the fields of the 1rtt header,
@@ -307,7 +307,7 @@ impl PacketHeaderBuilder {
     pub fn one_rtt(&mut self, header: &OneRttHeader) -> &mut Self {
         self.packet_type(PacketType::OneRTT)
             .dcil(header.dcid().len() as u8)
-            .scid(*header.dcid())
+            .dcid(*header.dcid())
     }
 }
 


### PR DESCRIPTION
and improve the current error handling, avoiding potential panic

ArcParameters内部有一个状态，作为表示正常状态的连接：Components的一部分，它还能表达不正常状态，而获取传输参数（比如这个pr添加的接口origin_dcid，比如创建路径时要获取ack_delay）不可避免地要处理错误

创建路径时返回None表示没有创建（一处在Path结构的new，获取不到Interface会返回None；一处是components尝试创建路径，获取不到参数或者获取不到Interface也会返回None），意义不是很符合

到了Connection暴露的接口上有一个很明显的问题：Connection的其他接口返回io::Error表示连接状态错误，但是Parameters::origin_dcid返回的是None，Connection拿到这个None还得想办法拿到Error再返回

不如直接让Parameters::origin返回Result？其他接口也顺便把连接错误和确实没有隔离开了，更整齐（虽然内部使用时不在乎None和Err的区别）

但是改动这一处又会带来更多的不整齐（和别的结构的接口）...