### PR TITLE
fix: fixed burst multiple segments

### DIFF
--- a/qconnection/src/path/burst.rs
+++ b/qconnection/src/path/burst.rs
@@ -127,7 +127,7 @@ impl Burst {
                     (Ok(segments), Err(limiter)) if segments.is_empty() => Break(Err(limiter)),
                     (Ok(segments), Err(_limiter)) => Break(Ok(segments)),
                     (Ok(mut segments), Ok(segment))
-                        if segments.len() < segments.last().copied().unwrap_or_default() =>
+                        if segment.len() < segments.last().copied().unwrap_or_default() =>
                     {
                         segments.push(segment.len());
                         Break(Ok(segments))


### PR DESCRIPTION
一次发送多个 segments 配合 sendmmsg 可以提高发送速度。
``` shell
# 修改前
INFO client: done! ↑ 20.9792s(190.6654MB/S), ↓ 21.0947s(189.6212MB/S)
#修改后
INFO client: done! ↑ 14.0287s(285.1289MB/S), ↓ 14.2228s(281.2387MB/S)
```
本地发送大文件时出现大批丢包的原因可能是系统限制的接收缓冲区, 调整了之后不再出现
```shell
> sudo sysctl -w net.core.rmem_max=268435456  # 256MB
net.core.rmem_max = 268435456
```
