### PR TITLE
refactor: remove duplicate and unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,11 @@ bitflags = "2"
 bytes = "1"
 cfg-if = "1"
 dashmap = "6"
-deref-derive = "0.1"
 derive_builder = "0.20"
 derive_more = "2"
 enum_dispatch = "0.3"
 futures = "0.3"
 getset = "0.1"
-log = "0.4"
 nom = "8"
 pin-project-lite = "0.2"
 rand = "0.9"
@@ -54,20 +52,18 @@ socket2 = "0.5"
 thiserror = "2"
 tokio = { version = "1" }
 tracing = "0.1"
-nix = { version = "0.29.0", features = ["socket", "uio", "net"] }
 
-# h3 for h3-shim, windows-sys and libc for qudp
+# h3 for h3-shim only , windows-sys, nix and libc for qudp only
 # they are not the default members of the workspace
 # h3 = "?"
 # windows-sys = "?"
 # libc = "0.2"
+# nix = "?"
 
 # dev-dependencies, for examples
 clap = { version = "4", features = ["derive"] }
-env_logger = "0.11"
 http = "1"
 tracing-subscriber = "0.3"
-url = "2"
 
 # members
 qbase = { path = "./qbase", version = "0.1.0" }

--- a/gm-quic/Cargo.toml
+++ b/gm-quic/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 bytes = { workspace = true }
 dashmap = { workspace = true }
-deref-derive = { workspace = true }
+derive_more = { workspace = true, features = ["deref"] }
 futures = { workspace = true }
 qbase = { workspace = true }
 qcongestion = { workspace = true }
@@ -30,10 +30,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 clap = { workspace = true }
-env_logger = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
-url = { workspace = true }
-log = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-std"] }
 
 [dev-dependencies.tracing-subscriber]

--- a/gm-quic/examples/echo_client.rs
+++ b/gm-quic/examples/echo_client.rs
@@ -7,7 +7,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tracing::info;
 
 #[derive(clap::Parser)]
-struct Opt {
+struct Options {
     #[arg(long)]
     server: SocketAddr,
 }
@@ -16,7 +16,7 @@ struct Opt {
 pub async fn main() -> io::Result<()> {
     tracing_subscriber::fmt().init();
 
-    let server_addr = Opt::parse().server;
+    let server_addr = Options::parse().server;
 
     let mut roots = RootCertStore::empty();
     roots.add_parsable_certificates(include_bytes!("keychain/localhost/ca.cert").to_certificate());

--- a/gm-quic/examples/echo_server.rs
+++ b/gm-quic/examples/echo_server.rs
@@ -5,7 +5,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{Instrument, info, info_span};
 
 #[derive(clap::Parser)]
-struct Opt {
+struct Options {
     #[arg(long, default_value = "0.0.0.0:0")]
     bind: SocketAddr,
 }
@@ -22,7 +22,7 @@ pub async fn main() -> io::Result<()> {
             include_bytes!("keychain/localhost/server.key"),
         )
         .with_parameters(server_stream_unlimited_parameters())
-        .listen(Opt::parse().bind)?;
+        .listen(Options::parse().bind)?;
 
     info!("listening on {:?}", server.addresses());
 

--- a/h3-shim/src/tests.rs
+++ b/h3-shim/src/tests.rs
@@ -24,13 +24,13 @@ async fn h3_test() {
         .init();
     // CryptoProvider ring is installed automatically.
 
-    let client_opt = client_example::Opt {
+    let client_opt = client_example::Options {
         ca: PathBuf::from("examples/ca.cert"),
         bind: vec!["127.0.0.1:0".parse().unwrap(), "[::1]:0".parse().unwrap()],
         uri: "https://localhost:4433/Cargo.toml".to_string(),
     };
 
-    let server_opt = server_example::Opt {
+    let server_opt = server_example::Options {
         root: PathBuf::from("./"),
         listen: vec![
             "127.0.0.1:4433".parse().unwrap(),

--- a/qbase/Cargo.toml
+++ b/qbase/Cargo.toml
@@ -14,10 +14,13 @@ categories.workspace = true
 [dependencies]
 bitflags = { workspace = true }
 bytes = { workspace = true }
-dashmap = { workspace = true }
-deref-derive = { workspace = true }
-derive_builder = { workspace = true }
-derive_more = { workspace = true, features = ["as_ref", "try_into", "from"] }
+derive_more = { workspace = true, features = [
+    "as_ref",
+    "deref",
+    "deref_mut",
+    "from",
+    "try_into",
+] }
 enum_dispatch = { workspace = true }
 futures = { workspace = true }
 getset = { workspace = true }

--- a/qbase/src/cid/remote_cid.rs
+++ b/qbase/src/cid/remote_cid.rs
@@ -412,8 +412,8 @@ where
         &self,
         tx_waker: ArcSendWaker,
     ) -> Result<Option<BorrowedCid<RETIRED>>, Signals> {
-        self.0.lock().unwrap().borrow_cid(tx_waker).map(|opt| {
-            opt.map(|cid| BorrowedCid {
+        self.0.lock().unwrap().borrow_cid(tx_waker).map(|cid| {
+            cid.map(|cid| BorrowedCid {
                 cid_cell: &self.0,
                 cid,
             })
@@ -461,7 +461,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use deref_derive::Deref;
+    use derive_more::Deref;
 
     use super::*;
 

--- a/qbase/src/flow.rs
+++ b/qbase/src/flow.rs
@@ -365,7 +365,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use deref_derive::{Deref, DerefMut};
+    use derive_more::{Deref, DerefMut};
 
     use super::*;
 

--- a/qbase/src/frame/new_token.rs
+++ b/qbase/src/frame/new_token.rs
@@ -1,4 +1,4 @@
-use deref_derive::Deref;
+use derive_more::Deref;
 
 use crate::varint::{VarInt, WriteVarInt, be_varint};
 

--- a/qbase/src/frame/path_challenge.rs
+++ b/qbase/src/frame/path_challenge.rs
@@ -1,4 +1,4 @@
-use deref_derive::Deref;
+use derive_more::Deref;
 
 /// PATH_CHALLENGE frame.
 ///

--- a/qbase/src/frame/path_response.rs
+++ b/qbase/src/frame/path_response.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use deref_derive::Deref;
+use derive_more::Deref;
 
 /// PATH_RESPONSE Frame.
 ///

--- a/qbase/src/handshake.rs
+++ b/qbase/src/handshake.rs
@@ -204,7 +204,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use deref_derive::Deref;
+    use derive_more::Deref;
 
     use super::*;
     use crate::{

--- a/qbase/src/net/tx.rs
+++ b/qbase/src/net/tx.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Waker},
 };
 
-use deref_derive::Deref;
+use derive_more::Deref;
 
 use super::route::Pathway;
 

--- a/qbase/src/packet.rs
+++ b/qbase/src/packet.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bytes::{BufMut, BytesMut, buf::UninitSlice};
-use deref_derive::{Deref, DerefMut};
+use derive_more::{Deref, DerefMut};
 use encrypt::{encode_long_first_byte, encode_short_first_byte, encrypt_packet, protect_header};
 use enum_dispatch::enum_dispatch;
 use getset::CopyGetters;
@@ -89,6 +89,7 @@ pub enum DataHeader {
 #[derive(Debug, Clone, Deref, DerefMut)]
 pub struct DataPacket {
     #[deref]
+    #[deref_mut]
     pub header: DataHeader,
     pub bytes: BytesMut,
     // payload_offset

--- a/qbase/src/packet/header/long.rs
+++ b/qbase/src/packet/header/long.rs
@@ -1,4 +1,4 @@
-use deref_derive::{Deref, DerefMut};
+use derive_more::{Deref, DerefMut};
 
 use super::*;
 use crate::{cid::ConnectionId, varint::VarInt};
@@ -28,6 +28,7 @@ pub struct LongHeader<T> {
     dcid: ConnectionId,
     scid: ConnectionId,
     #[deref]
+    #[deref_mut]
     specific: T,
 }
 

--- a/qbase/src/packet/io.rs
+++ b/qbase/src/packet/io.rs
@@ -152,6 +152,7 @@ impl PacketLayout {
 #[derive(Deref, DerefMut)]
 pub struct PacketWriter<'b> {
     #[deref]
+    #[deref_mut]
     layout: PacketLayout,
     buffer: &'b mut [u8],
 }

--- a/qbase/src/packet/type.rs
+++ b/qbase/src/packet/type.rs
@@ -1,4 +1,4 @@
-use deref_derive::Deref;
+use derive_more::Deref;
 
 use super::{KeyPhaseBit, PacketNumber, error::Error};
 

--- a/qbase/src/packet/type/long.rs
+++ b/qbase/src/packet/type/long.rs
@@ -1,4 +1,4 @@
-use deref_derive::Deref;
+use derive_more::Deref;
 
 /// Supports IQuic version 1, if other versions are supported in the future, add them here.
 pub mod v1;

--- a/qbase/src/packet/type/short.rs
+++ b/qbase/src/packet/type/short.rs
@@ -1,5 +1,5 @@
 use bytes::BufMut;
-use deref_derive::Deref;
+use derive_more::Deref;
 
 use crate::packet::SpinBit;
 

--- a/qbase/src/sid/local_sid.rs
+++ b/qbase/src/sid/local_sid.rs
@@ -164,7 +164,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use deref_derive::Deref;
+    use derive_more::Deref;
 
     use super::*;
     use crate::util::ArcAsyncDeque;

--- a/qbase/src/sid/remote_sid.rs
+++ b/qbase/src/sid/remote_sid.rs
@@ -238,7 +238,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use deref_derive::Deref;
+    use derive_more::Deref;
 
     use super::*;
     use crate::{sid::handy::ConsistentConcurrency, util::ArcAsyncDeque};

--- a/qbase/src/token.rs
+++ b/qbase/src/token.rs
@@ -1,7 +1,7 @@
 use std::{ops::Deref, sync::Arc};
 
 use bytes::BufMut;
-use deref_derive::Deref;
+use derive_more::Deref;
 use nom::{IResult, bytes::complete::take};
 use rand::Rng;
 

--- a/qcongestion/Cargo.toml
+++ b/qcongestion/Cargo.toml
@@ -15,9 +15,7 @@ categories.workspace = true
 tracing = { workspace = true }
 qbase = { workspace = true }
 qlog = { workspace = true }
-qrecovery = { workspace = true }
 rand = { workspace = true }
-dashmap = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "time", "macros"] }
 
 [dev-dependencies]

--- a/qconnection/Cargo.toml
+++ b/qconnection/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 [dependencies]
 bytes = { workspace = true }
 dashmap = { workspace = true }
-deref-derive = { workspace = true }
+derive_more = { workspace = true, features = ["deref"] }
 futures = { workspace = true }
 qbase = { workspace = true }
 qcongestion = { workspace = true }

--- a/qconnection/src/path/paths.rs
+++ b/qconnection/src/path/paths.rs
@@ -1,7 +1,7 @@
 use std::{io, sync::Arc, time::Duration};
 
 use dashmap::DashMap;
-use deref_derive::Deref;
+use derive_more::Deref;
 use qbase::{
     Epoch,
     error::{Error, ErrorKind},

--- a/qconnection/src/tx.rs
+++ b/qconnection/src/tx.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use bytes::BufMut;
-use deref_derive::Deref;
+use derive_more::Deref;
 use qbase::{
     Epoch,
     cid::{BorrowedCid, ConnectionId},

--- a/qinterface/Cargo.toml
+++ b/qinterface/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 bytes = { workspace = true }
 dashmap = { workspace = true }
-deref-derive = { workspace = true }
+derive_more = { workspace = true, features = ["deref"] }
 qbase = { workspace = true }
 qlog = { workspace = true }
 rustls = { workspace = true }

--- a/qinterface/src/packet.rs
+++ b/qinterface/src/packet.rs
@@ -1,5 +1,5 @@
 use bytes::{Bytes, BytesMut};
-use deref_derive::Deref;
+use derive_more::Deref;
 use qbase::{
     error::Error,
     packet::{

--- a/qrecovery/Cargo.toml
+++ b/qrecovery/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 
 [dependencies]
 bytes = { workspace = true }
-deref-derive = { workspace = true }
+derive_more = { workspace = true, features = ["deref"] }
 enum_dispatch = { workspace = true }
 futures = { workspace = true }
 qbase = { workspace = true }

--- a/qrecovery/src/journal/sent.rs
+++ b/qrecovery/src/journal/sent.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use deref_derive::{Deref, DerefMut};
+use derive_more::{Deref, DerefMut};
 use qbase::{
     error::{Error, ErrorKind},
     frame::{AckFrame, BeFrame},
@@ -134,6 +134,7 @@ impl SentPktState {
 #[derive(Debug, Default, Deref, DerefMut)]
 struct SentJournal<T> {
     #[deref]
+    #[deref_mut]
     queue: VecDeque<T>,
     // 记录着每个包的内容，其实是一个数字，该数字对应着queue中的record数量
     sent_packets: IndexDeque<SentPktState, VARINT_MAX>,

--- a/qrecovery/src/streams.rs
+++ b/qrecovery/src/streams.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use deref_derive::Deref;
+use derive_more::Deref;
 pub use listener::{AcceptBiStream, AcceptUniStream};
 use qbase::{
     error::Error,

--- a/qrecovery/src/streams/io.rs
+++ b/qrecovery/src/streams/io.rs
@@ -6,7 +6,7 @@ use std::{
     },
 };
 
-use deref_derive::{Deref, DerefMut};
+use derive_more::{Deref, DerefMut};
 use qbase::{error::Error as QuicError, sid::StreamId};
 
 use crate::{recv::Incoming, send::Outgoing};
@@ -46,6 +46,7 @@ impl IOState {
 #[derive(Debug, Clone, Deref, DerefMut)]
 pub(super) struct Output<TX> {
     #[deref]
+    #[deref_mut]
     pub(super) outgoings: BTreeMap<StreamId, (Outgoing<TX>, IOState)>,
     pub(super) cursor: Option<(StreamId, usize)>,
 }

--- a/qudp/Cargo.toml
+++ b/qudp/Cargo.toml
@@ -14,10 +14,10 @@ categories.workspace = true
 bytes = { workspace = true }
 cfg-if = { workspace = true }
 libc = "0.2"
-tracing = {workspace = true}
+tracing = { workspace = true }
 socket2 = { workspace = true }
 tokio = { workspace = true, features = ["net"] }
-nix = {workspace = true}
+nix = { version = "0.29.0", features = ["socket", "uio", "net"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [
@@ -28,7 +28,6 @@ windows-sys = { version = "0.59", features = [
 
 [dev-dependencies]
 clap = { workspace = true }
-env_logger = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "macros"] }
 
 [dev-dependencies.tracing-subscriber]


### PR DESCRIPTION
`derive-deref`的功能`derive_more`全部实现了，去重

`log`, `env_logger` 是遗留，现在换成`tracing`

`uri` 没地方用

`nix` 是qudp独有的依赖，而qudp不是`default-member`，依赖写在`qudp/Cargo.toml`更合适