### PR TITLE
Derive `Clone` for `qconnection::Connection`

### DIFF
--- a/qconnection/src/lib.rs
+++ b/qconnection/src/lib.rs
@@ -430,6 +430,7 @@ struct ConnectionState {
     tracing_span: tracing::Span,
 }
 
+#[derive(Clone)]
 pub struct Connection(Arc<ConnectionState>);
 
 impl ConnectionState {


### PR DESCRIPTION
While `Connection` is meant to be an opaque pointer, its only member (an `Arc<ConnectionState>`) is trivially cloneable. This small PR derives `Clone` for `qconnection::Connection` so that gm-quic consumers can clone it without wrapping it in their own `Arc`, avoiding double indirection (`Arc<Connection>` aka `Arc<Connection(Arc<ConnectionState>)>`.