### PR TITLE
fix(qrecovery): emit StreamStateUpdated event and handle Ready state on stop_sending

### DIFF
--- a/qconnection/src/space.rs
+++ b/qconnection/src/space.rs
@@ -160,12 +160,8 @@ impl ReceiveFrame<(StreamFrame, Bytes)> for FlowControlledDataStreams {
 
     fn recv_frame(&self, data_frame: (StreamFrame, Bytes)) -> Result<Self::Output, Error> {
         let frame_type = data_frame.0.frame_type();
-        match self.streams.recv_data(data_frame) {
-            Ok(new_data_size) => {
-                self.flow_ctrl.on_new_rcvd(frame_type, new_data_size)?;
-            }
-            Err(e) => return Err(e.into()),
-        }
+        let new_data_size = self.streams.recv_data(data_frame)?;
+        self.flow_ctrl.on_new_rcvd(frame_type, new_data_size)?;
         Ok(())
     }
 }
@@ -174,13 +170,9 @@ impl ReceiveFrame<StreamCtlFrame> for FlowControlledDataStreams {
     type Output = ();
 
     fn recv_frame(&self, frame: StreamCtlFrame) -> Result<Self::Output, Error> {
-        match self.streams.recv_stream_control(frame) {
-            Ok(new_data_size) => {
-                self.flow_ctrl
-                    .on_new_rcvd(frame.frame_type(), new_data_size)?;
-            }
-            Err(e) => return Err(e.into()),
-        }
+        let new_data_size = self.streams.recv_stream_control(frame)?;
+        self.flow_ctrl
+            .on_new_rcvd(frame.frame_type(), new_data_size)?;
         Ok(())
     }
 }

--- a/qrecovery/src/send/outgoing.rs
+++ b/qrecovery/src/send/outgoing.rs
@@ -195,30 +195,39 @@ impl<TX> Outgoing<TX> {
         let mut sender = self.0.sender();
         let inner = sender.deref_mut();
         match inner {
-            Ok(sending_state) => match sending_state {
-                Sender::Ready(_) => {
-                    unreachable!("never send data before recv data");
-                }
-                Sender::Sending(s) => {
-                    let final_size = s.be_stopped();
-                    let reset = ResetStreamError::new(
-                        VarInt::from_u64(error_code).expect("app error code must not exceed 2^62"),
-                        VarInt::from_u64(final_size).expect("final size must not exceed 2^62"),
-                    );
-                    *sending_state = Sender::ResetSent(reset);
-                    Some(final_size)
-                }
-                Sender::DataSent(s) => {
-                    let final_size = s.be_stopped();
-                    let reset = ResetStreamError::new(
-                        VarInt::from_u64(error_code).expect("app error code must not exceed 2^62"),
-                        VarInt::from_u64(final_size).expect("final size must not exceed 2^62"),
-                    );
-                    *sending_state = Sender::ResetSent(reset);
-                    Some(final_size)
-                }
-                _ => None,
-            },
+            Ok(sending_state) => {
+                // THINK: sending_state.stream_id() -> StreamId, sending_state.state() -> GranularStreamStates
+                let (stream_id, old_state, final_size) = match sending_state {
+                    Sender::Ready(s) => {
+                        (s.stream_id(), GranularStreamStates::Ready, s.be_stopped())
+                    }
+                    Sender::Sending(s) => {
+                        (s.stream_id(), GranularStreamStates::Send, s.be_stopped())
+                    }
+                    Sender::DataSent(s) => (
+                        s.stream_id(),
+                        GranularStreamStates::DataSent,
+                        s.be_stopped(),
+                    ),
+                    _ => return None,
+                };
+                let reset = ResetStreamError::new(
+                    // TODO: many places in the codebase perform VarInt -> u64 -> VarInt conversion
+                    //  which is redundant and may cause bugs, consider refactor call-chain.
+                    VarInt::from_u64(error_code).expect("app error code must not exceed 2^62"),
+                    VarInt::from_u64(final_size).expect("final size must not exceed 2^62"),
+                );
+
+                qevent::event!(StreamStateUpdated {
+                    stream_id: stream_id.id(),
+                    stream_type: stream_id.dir(),
+                    old: old_state,
+                    new: GranularStreamStates::ResetReceived,
+                    stream_side: StreamSide::Sending
+                });
+                *sending_state = Sender::ResetSent(reset);
+                Some(final_size)
+            }
             Err(_) => None,
         }
     }
@@ -226,6 +235,7 @@ impl<TX> Outgoing<TX> {
     /// Called When the [`RESET_STREAM frame`] previously sent to the peer is acknowledged
     ///
     /// [`RESET_STREAM frame`]: https://www.rfc-editor.org/rfc/rfc9000.html#name-reset_stream-frames
+    // TODO: stream id not from stream state, consider refactor. (many other places in qrecovery)
     pub fn on_reset_acked(&self, sid: StreamId) {
         let mut sender = self.0.sender();
         let inner = sender.deref_mut();

--- a/qrecovery/src/send/sender.rs
+++ b/qrecovery/src/send/sender.rs
@@ -174,6 +174,13 @@ impl<TX> ReadySender<TX> {
             waker.wake();
         }
     }
+
+    pub(super) fn be_stopped(&mut self) -> u64 {
+        self.wake_all();
+        // ReadyState: no data is sent
+        debug_assert_eq!(self.sndbuf.sent(), 0);
+        self.sndbuf.sent()
+    }
 }
 
 /// 状态升级，ReaderSender => SendingSender
@@ -459,6 +466,10 @@ pub struct DataSentSender<TX> {
 }
 
 impl<TX> DataSentSender<TX> {
+    pub(super) fn stream_id(&self) -> StreamId {
+        self.stream_id
+    }
+
     pub(super) fn pick_up<P>(
         &'_ mut self,
         predicate: P,


### PR DESCRIPTION
previously be_stopped handling treated Ready state as unreachable and did not emit the qlog StreamStateUpdated event when transitioning to ResetSent. handle Ready state properly and emit the state-updated event for all transitions.